### PR TITLE
Refine hero content and add sidebar

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["next/core-web-vitals", "next/typescript"]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,37 @@
+# See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
+
+# dependencies
+package-lock.json
+/node_modules
+/.pnp
+.pnp.js
+.yarn/install-state.gz
+
+# testing
+/coverage
+
+# next.js
+/.next/
+/out/
+
+# production
+/build
+
+# misc
+.DS_Store
+*.pem
+
+# debug
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# local env files
+.env*.local
+
+# vercel
+.vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/README.md
+++ b/README.md
@@ -1,0 +1,38 @@
+Affinity is a mobile-first relationship profiling quiz built with Next.js 14.
+
+This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+
+## Getting Started
+
+First, run the development server:
+
+```bash
+npm run dev
+# or
+yarn dev
+# or
+pnpm dev
+# or
+bun dev
+```
+
+Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+
+You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
+
+This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to load [Inter](https://fonts.google.com/specimen/Inter) from Google Fonts with optimal performance.
+
+## Learn More
+
+To learn more about Next.js, take a look at the following resources:
+
+- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
+- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
+
+You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
+
+## Deploy on Vercel
+
+The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
+
+Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,0 +1,4 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {};
+
+export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "affinity",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "framer-motion": "^12.23.12",
+    "lucide-react": "^0.542.0",
+    "next": "14.2.10",
+    "react": "^18",
+    "react-dom": "^18",
+    "recharts": "^3.1.2"
+  },
+  "devDependencies": {
+    "@types/node": "^20",
+    "@types/react": "^18",
+    "@types/react-dom": "^18",
+    "eslint": "^8",
+    "eslint-config-next": "14.2.10",
+    "postcss": "^8",
+    "tailwindcss": "^3.4.1",
+    "typescript": "^5"
+  }
+}

--- a/postcss.config.mjs
+++ b/postcss.config.mjs
@@ -1,0 +1,8 @@
+/** @type {import('postcss-load-config').Config} */
+const config = {
+  plugins: {
+    tailwindcss: {},
+  },
+};
+
+export default config;

--- a/src/app/checkout/page.tsx
+++ b/src/app/checkout/page.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import { useState } from "react";
+import PageTransition from "@/components/PageTransition";
+import Container from "@/components/Container";
+import Skeleton from "@/components/Skeleton";
+
+export default function CheckoutPage() {
+  const [loaded, setLoaded] = useState(false);
+  return (
+    <PageTransition>
+      <section className="py-12">
+        <Container className="max-w-[740px]">
+          {!loaded && <Skeleton className="h-96 w-full" />}
+          <iframe
+            src="https://gumroad.com/l/placeholder?embedded=1"
+            className="h-96 w-full"
+            onLoad={() => setLoaded(true)}
+          />
+        </Container>
+      </section>
+    </PageTransition>
+  );
+}

--- a/src/app/come-funziona/page.tsx
+++ b/src/app/come-funziona/page.tsx
@@ -1,0 +1,44 @@
+import PageTransition from "@/components/PageTransition";
+import Container from "@/components/Container";
+import { ListChecks, Brain, Target } from "lucide-react";
+
+export default function ComeFunzionaPage() {
+  return (
+    <PageTransition>
+      <section className="py-12">
+        <Container className="max-w-[740px] space-y-12">
+          <h1 className="text-center text-3xl font-bold">Come funziona</h1>
+          <div className="space-y-8">
+            <div className="flex items-start gap-4">
+              <ListChecks className="h-6 w-6 text-red" />
+              <div>
+                <h2 className="font-semibold">Test strutturato</h2>
+                <p className="text-sm text-gray-400">
+                  Ogni domanda è pensata per rivelare aspetti chiave del tuo modo di vivere le relazioni.
+                </p>
+              </div>
+            </div>
+            <div className="flex items-start gap-4">
+              <Brain className="h-6 w-6 text-red" />
+              <div>
+                <h2 className="font-semibold">Modello di profilo</h2>
+                <p className="text-sm text-gray-400">
+                  Analizziamo le tue risposte e calcoliamo un profilo sintetico basato su studi scientifici.
+                </p>
+              </div>
+            </div>
+            <div className="flex items-start gap-4">
+              <Target className="h-6 w-6 text-red" />
+              <div>
+                <h2 className="font-semibold">Consigli pratici</h2>
+                <p className="text-sm text-gray-400">
+                  Ricevi suggerimenti immediati per migliorare le tue interazioni quotidiane.
+                </p>
+              </div>
+            </div>
+          </div>
+        </Container>
+      </section>
+    </PageTransition>
+  );
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,0 +1,32 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  --bg: #0B0B0B;
+  --fg: #FFFFFF;
+  --border: #1F1F1F;
+  --red: #E50914;
+  --red-dim: #A30710;
+}
+
+body {
+  color: var(--fg);
+  background-color: var(--bg);
+  background-image:
+    radial-gradient(circle at center, rgba(229,9,20,0.15), rgba(11,11,11,0) 70%),
+    url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='200' height='200' viewBox='0 0 200 200'><filter id='g'><feTurbulence type='fractalNoise' baseFrequency='0.8' numOctaves='4'/></filter><rect width='100%' height='100%' filter='url(%23g)' opacity='0.15'/></svg>");
+  background-attachment: fixed;
+  font-family: var(--font-inter), sans-serif;
+}
+
+*:focus-visible {
+  outline: 2px solid var(--red);
+  outline-offset: 2px;
+}
+
+@layer utilities {
+  .text-balance {
+    text-wrap: balance;
+  }
+}

--- a/src/app/grazie/page.tsx
+++ b/src/app/grazie/page.tsx
@@ -1,0 +1,19 @@
+import PageTransition from "@/components/PageTransition";
+import Container from "@/components/Container";
+import CTAButton from "@/components/CTAButton";
+
+export default function GraziePage() {
+  return (
+    <PageTransition>
+      <section className="flex items-center justify-center py-24 text-center">
+        <Container className="space-y-4">
+          <h1 className="text-3xl font-bold">Grazie! Il tuo PDF è pronto</h1>
+          <p className="text-gray-400">
+            Riceverai il link da Gumroad. Controlla anche lo spam
+          </p>
+          <CTAButton href="/">Torna alla Home</CTAButton>
+        </Container>
+      </section>
+    </PageTransition>
+  );
+}

--- a/src/app/icon.svg
+++ b/src/app/icon.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <circle cx="16" cy="16" r="16" fill="#E50914"/>
+</svg>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,0 +1,32 @@
+import type { Metadata } from "next";
+import { Inter } from "next/font/google";
+import "./globals.css";
+import Header from "@/components/Header";
+import Footer from "@/components/Footer";
+import Sidebar from "@/components/Sidebar";
+
+const inter = Inter({ subsets: ["latin"], variable: "--font-inter" });
+
+export const metadata: Metadata = {
+  title: "Affinity",
+  description: "Il test che rivela il tuo profilo nelle relazioni",
+};
+
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <html lang="it" className={inter.variable}>
+      <body className="bg-bg text-fg antialiased">
+        <Sidebar />
+        <div className="ml-0 sm:ml-16">
+          <Header />
+          <main className="min-h-screen">{children}</main>
+          <Footer />
+        </div>
+      </body>
+    </html>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,0 +1,41 @@
+import PageTransition from "@/components/PageTransition";
+import Container from "@/components/Container";
+import CTAButton from "@/components/CTAButton";
+import { FlaskConical, Gift, FileText } from "lucide-react";
+
+export default function Home() {
+  return (
+    <PageTransition>
+      <section className="flex flex-col items-center justify-center py-24 text-center">
+        <Container className="space-y-8">
+          <div className="inline-block rounded-full bg-red px-3 py-1 text-xs font-semibold">
+            +20.000 persone hanno già fatto il test
+          </div>
+          <h1 className="mx-auto max-w-3xl text-4xl font-bold">
+            Scopri perché le tue relazioni non funzionano
+          </h1>
+          <p className="mx-auto max-w-2xl text-lg text-gray-400">
+            Basato su oltre 50 studi e libri di psicologia dell’attrazione e delle relazioni.
+          </p>
+          <CTAButton href="/test" className="px-8 py-4">
+            Inizia ora il test gratuito — scopri il tuo profilo in meno di 5 minuti.
+          </CTAButton>
+          <div className="grid gap-6 pt-16 sm:grid-cols-3">
+            <div className="flex flex-col items-center space-y-2">
+              <FlaskConical className="h-8 w-8 text-red" />
+              <p>Evidence-based</p>
+            </div>
+            <div className="flex flex-col items-center space-y-2">
+              <Gift className="h-8 w-8 text-red" />
+              <p>Risultato gratuito</p>
+            </div>
+            <div className="flex flex-col items-center space-y-2">
+              <FileText className="h-8 w-8 text-red" />
+              <p>Report premium</p>
+            </div>
+          </div>
+        </Container>
+      </section>
+    </PageTransition>
+  );
+}

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -1,0 +1,17 @@
+import PageTransition from "@/components/PageTransition";
+import Container from "@/components/Container";
+
+export default function PrivacyPage() {
+  return (
+    <PageTransition>
+      <section className="py-12">
+        <Container className="max-w-[740px] space-y-4">
+          <h1 className="text-3xl font-bold">Privacy</h1>
+          <p className="text-gray-400">
+            Dati anonimi, LocalStorage only, nessun tracking personale.
+          </p>
+        </Container>
+      </section>
+    </PageTransition>
+  );
+}

--- a/src/app/risultati/page.tsx
+++ b/src/app/risultati/page.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import PageTransition from "@/components/PageTransition";
+import Container from "@/components/Container";
+import ResultChart from "@/components/ResultChart";
+import CTAButton from "@/components/CTAButton";
+import { FileText } from "lucide-react";
+
+const labels = ["Umore", "Socialità", "Sicurezza", "Messaggi", "Iniziativa"];
+
+function getProfile(score: number) {
+  if (score < 40) return "Esploratore Riflessivo";
+  if (score < 60) return "Equilibrista Pragmatico";
+  if (score < 80) return "Leader Calmo";
+  return "Catalizzatore Sicuro";
+}
+
+export default function ResultsPage() {
+  const [scores, setScores] = useState<number[]>([]);
+  const [total, setTotal] = useState(0);
+
+  useEffect(() => {
+    const stored = localStorage.getItem("affinity.answers.v1");
+    if (stored) {
+      try {
+        const ans: number[] = JSON.parse(stored);
+        if (Array.isArray(ans) && ans.length > 0) {
+          const groups = labels.map((_, i) => {
+            const group = ans.filter((_, idx) => idx % labels.length === i);
+            return group.reduce((a, b) => a + b, 0) / group.length;
+          });
+          setScores(groups);
+          const avg = ans.reduce((a, b) => a + b, 0) / ans.length;
+          setTotal(avg * 20);
+        }
+      } catch {
+        /* ignore */
+      }
+    }
+  }, []);
+
+  if (!scores.length) {
+    return (
+      <PageTransition>
+        <section className="py-12">
+          <Container>
+            <p>Nessun dato trovato.</p>
+          </Container>
+        </section>
+      </PageTransition>
+    );
+  }
+
+  const profile = getProfile(total);
+  const data = labels.map((l, i) => ({ name: l, value: scores[i] * 20 }));
+
+  return (
+    <PageTransition>
+      <section className="py-12">
+        <Container className="max-w-[740px] space-y-8">
+          <h1 className="text-3xl font-bold">Il tuo profilo: {profile}</h1>
+          <p className="text-lg">Livello di Attrazione: {Math.round(total)}/100</p>
+          <ResultChart data={data} />
+          <ul className="list-disc space-y-2 pl-5 text-gray-400">
+            <li>Ricorda di essere autentico in ogni interazione.</li>
+            <li>Ascolta attivamente chi ti sta vicino.</li>
+            <li>Prenota momenti per riflettere su di te.</li>
+          </ul>
+          <div className="pt-4">
+            <CTAButton
+              href="/checkout"
+              className="flex w-full items-center gap-2 px-6 py-3 sm:w-auto"
+            >
+              <FileText className="h-4 w-4" />
+              Scarica il report completo (PDF)
+            </CTAButton>
+          </div>
+        </Container>
+      </section>
+    </PageTransition>
+  );
+}

--- a/src/app/termini/page.tsx
+++ b/src/app/termini/page.tsx
@@ -1,0 +1,17 @@
+import PageTransition from "@/components/PageTransition";
+import Container from "@/components/Container";
+
+export default function TerminiPage() {
+  return (
+    <PageTransition>
+      <section className="py-12">
+        <Container className="max-w-[740px] space-y-4">
+          <h1 className="text-3xl font-bold">Termini &amp; condizioni</h1>
+          <p className="text-gray-400">
+            Dati anonimi, LocalStorage only, nessun tracking personale.
+          </p>
+        </Container>
+      </section>
+    </PageTransition>
+  );
+}

--- a/src/app/test/page.tsx
+++ b/src/app/test/page.tsx
@@ -1,0 +1,182 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import PageTransition from "@/components/PageTransition";
+import Container from "@/components/Container";
+import Card from "@/components/Card";
+import QuestionStep, { Question } from "@/components/QuestionStep";
+import ProgressBar from "@/components/ProgressBar";
+import CTAButton from "@/components/CTAButton";
+import { useRouter } from "next/navigation";
+import { Info } from "lucide-react";
+
+const baseQuestions: Question[] = [
+  {
+    category: "Umore",
+    icon: "⚡",
+    text: "Come descriveresti il tuo umore generale oggi?",
+  },
+  {
+    category: "Socialità",
+    icon: "💬",
+    text: "Quanto ti piace fare nuove conoscenze?",
+  },
+  {
+    category: "Sicurezza",
+    icon: "⚡",
+    text: "Quanto spesso ti senti sicuro/a di te in pubblico?",
+  },
+  {
+    category: "Messaggi",
+    icon: "💬",
+    text: "Come reagisci ai messaggi ‘visti ma non risposti’?",
+  },
+  {
+    category: "Iniziativa",
+    icon: "❤️",
+    text: "Quanto ti piace prendere l’iniziativa?",
+  },
+];
+
+const BLURBS = [
+  {
+    index: 4,
+    text: "Questi ruoli derivano da studi pubblicati sul Journal of Personality and Social Psychology.",
+  },
+  {
+    index: 14,
+    text: "Le domande si basano su oltre 50 studi di psicologia delle relazioni.",
+  },
+];
+
+const QUESTIONS: Question[] = Array.from({ length: 30 }, (_, i) => baseQuestions[i % baseQuestions.length]);
+
+export default function TestPage() {
+  const total = QUESTIONS.length;
+  const router = useRouter();
+  const [current, setCurrent] = useState(0);
+  const [answers, setAnswers] = useState<number[]>(Array(total).fill(0));
+  const [showResume, setShowResume] = useState(false);
+
+  useEffect(() => {
+    const stored = localStorage.getItem("affinity.answers.v1");
+    if (stored) {
+      try {
+        const parsed = JSON.parse(stored);
+        if (Array.isArray(parsed) && parsed.length === total) {
+          setAnswers(parsed);
+          setShowResume(true);
+        }
+      } catch {
+        /* ignore */
+      }
+    }
+  }, [total]);
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === "ArrowRight") next();
+      if (e.key === "ArrowLeft") prev();
+      const num = Number(e.key);
+      if (num >= 1 && num <= 5) select(num);
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  });
+
+  const select = (val: number) => {
+    const newAns = [...answers];
+    newAns[current] = val;
+    setAnswers(newAns);
+    localStorage.setItem("affinity.answers.v1", JSON.stringify(newAns));
+  };
+
+  const next = () => {
+    if (!answers[current]) return;
+    if (current < total - 1) setCurrent((c) => c + 1);
+    else router.push("/risultati");
+  };
+
+  const prev = () => {
+    if (current > 0) setCurrent((c) => c - 1);
+  };
+
+  const resume = () => {
+    const firstUnanswered = answers.findIndex((a) => a === 0);
+    setCurrent(firstUnanswered === -1 ? 0 : firstUnanswered);
+    setShowResume(false);
+  };
+
+  const restart = () => {
+    const empty = Array(total).fill(0);
+    setAnswers(empty);
+    localStorage.setItem("affinity.answers.v1", JSON.stringify(empty));
+    setCurrent(0);
+    setShowResume(false);
+  };
+
+  return (
+    <PageTransition>
+      <section className="py-12">
+        <Container className="flex flex-col items-center">
+          {showResume && (
+            <div className="mb-4 flex w-full max-w-[740px] items-center justify-between rounded-md border border-border bg-bg p-4 text-sm">
+              <span>Vuoi riprendere?</span>
+              <div className="flex gap-2">
+                <button onClick={restart} className="underline">
+                  Ricomincia
+                </button>
+                <button onClick={resume} className="text-red underline">
+                  Riprendi
+                </button>
+              </div>
+            </div>
+          )}
+          <Card className="w-full max-w-[740px] space-y-8">
+            <div className="sticky top-0 z-10 pb-4">
+              <ProgressBar current={current + 1} total={total} />
+              <p className="mt-2 text-sm" aria-live="polite">
+                Domanda {current + 1} di {total}
+              </p>
+            </div>
+            <QuestionStep
+              question={QUESTIONS[current]}
+              answer={answers[current]}
+              onSelect={select}
+            />
+            {(() => {
+              const blurb = BLURBS.find((b) => b.index === current);
+              if (!blurb) return null;
+              return (
+                <div className="flex items-start gap-2 rounded-md border border-border p-3 text-sm text-gray-300">
+                  <Info className="mt-0.5 h-4 w-4 text-gray-400" />
+                  <p>{blurb.text}</p>
+                </div>
+              );
+            })()}
+            <div className="flex items-center justify-between pt-4">
+              <button
+                onClick={prev}
+                className="text-sm text-gray-400 disabled:opacity-50"
+                disabled={current === 0}
+              >
+                Indietro
+              </button>
+              <div className="flex items-center gap-4">
+                <button onClick={next} className="text-sm text-gray-400">
+                  Salta
+                </button>
+                <CTAButton onClick={next} disabled={!answers[current]}>
+                  Avanti
+                </CTAButton>
+              </div>
+            </div>
+            <div className="pt-4">
+              <ProgressBar current={current + 1} total={total} />
+            </div>
+          </Card>
+        </Container>
+      </section>
+    </PageTransition>
+  );
+}

--- a/src/components/CTAButton.tsx
+++ b/src/components/CTAButton.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import Link from "next/link";
+import { motion } from "framer-motion";
+import { ReactNode } from "react";
+
+type Props = {
+  href?: string;
+  children: ReactNode;
+  className?: string;
+  onClick?: () => void;
+  disabled?: boolean;
+  type?: "button" | "submit";
+};
+
+const MotionLink = motion(Link);
+
+export default function CTAButton({
+  href,
+  children,
+  className = "",
+  onClick,
+  disabled = false,
+  type = "button",
+}: Props) {
+  const base = `inline-flex items-center justify-center rounded-md bg-red px-5 py-2 font-semibold text-fg shadow-[0_0_8px_rgba(229,9,20,0.15)] transition-colors ${
+    disabled ? "cursor-not-allowed opacity-50" : "hover:bg-red-dim"
+  }`;
+  const motionProps = {
+    whileHover: disabled
+      ? {}
+      : { y: -2, boxShadow: "0 0 8px rgba(229,9,20,0.3)" },
+    whileTap: disabled ? {} : { y: 1 },
+  };
+  if (href) {
+    return (
+      <MotionLink
+        href={href}
+        className={`${base} ${className}`}
+        {...motionProps}
+        onClick={onClick}
+      >
+        {children}
+      </MotionLink>
+    );
+  }
+  return (
+    <motion.button
+      className={`${base} ${className}`}
+      {...motionProps}
+      onClick={onClick}
+      disabled={disabled}
+      type={type}
+    >
+      {children}
+    </motion.button>
+  );
+}

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -1,0 +1,7 @@
+import { ReactNode } from "react";
+
+export default function Card({ children, className = "" }: { children: ReactNode; className?: string }) {
+  return (
+    <div className={`rounded-2xl border border-border bg-bg p-8 ${className}`}>{children}</div>
+  );
+}

--- a/src/components/Container.tsx
+++ b/src/components/Container.tsx
@@ -1,0 +1,5 @@
+import { ReactNode } from "react";
+
+export default function Container({ children, className = "" }: { children: ReactNode; className?: string }) {
+  return <div className={`mx-auto w-full max-w-container px-4 ${className}`}>{children}</div>;
+}

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,0 +1,24 @@
+import Link from "next/link";
+import Container from "./Container";
+
+export default function Footer() {
+  return (
+    <footer className="mt-16 border-t border-border">
+      <Container className="flex flex-col items-center justify-between gap-4 py-6 text-sm sm:flex-row">
+        <div className="flex gap-4">
+          <Link
+            href="https://instagram.com/getaffinity"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="hover:text-red"
+          >
+            Instagram
+          </Link>
+        </div>
+        <Link href="/termini" className="hover:text-red">
+          Termini e condizioni
+        </Link>
+      </Container>
+    </footer>
+  );
+}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,0 +1,22 @@
+import Link from "next/link";
+import Container from "./Container";
+import CTAButton from "./CTAButton";
+
+export default function Header() {
+  return (
+    <header className="sticky top-0 z-50 border-b border-border bg-bg/80 backdrop-blur">
+      <Container className="flex h-16 items-center justify-between pl-2 pr-2">
+        <Link href="/" className="text-2xl font-bold">Affinity</Link>
+        <nav className="ml-auto flex items-center gap-6 text-sm">
+          <Link href="/come-funziona" className="hover:text-red">
+            Come funziona
+          </Link>
+          <Link href="/privacy" className="hover:text-red">
+            Privacy
+          </Link>
+          <CTAButton href="/test">Inizia</CTAButton>
+        </nav>
+      </Container>
+    </header>
+  );
+}

--- a/src/components/PageTransition.tsx
+++ b/src/components/PageTransition.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+import { motion } from "framer-motion";
+import { ReactNode } from "react";
+
+export default function PageTransition({ children }: { children: ReactNode }) {
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 16 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.2 }}
+    >
+      {children}
+    </motion.div>
+  );
+}

--- a/src/components/ProgressBar.tsx
+++ b/src/components/ProgressBar.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import { motion } from "framer-motion";
+
+export default function ProgressBar({ current, total }: { current: number; total: number }) {
+  const progress = (current / total) * 100;
+  return (
+    <div className="w-full">
+      <div className="h-2 w-full rounded-full bg-red/30">
+        <motion.div
+          className="h-2 rounded-full bg-fg"
+          initial={{ width: 0 }}
+          animate={{ width: `${progress}%` }}
+          transition={{ type: "spring", duration: 0.35 }}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/components/QuestionStep.tsx
+++ b/src/components/QuestionStep.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { motion } from "framer-motion";
+import { Check } from "lucide-react";
+
+const options = ["Per niente", "Poco", "Abbastanza", "Molto", "Moltissimo"];
+
+export type Question = {
+  category: string;
+  text: string;
+  icon: string;
+};
+
+export default function QuestionStep({
+  question,
+  answer,
+  onSelect,
+}: {
+  question: Question;
+  answer?: number;
+  onSelect: (val: number) => void;
+}) {
+  return (
+    <div className="space-y-6">
+      <div className="text-sm text-gray-400">{question.category}</div>
+      <h2 className="flex items-center gap-2 text-2xl font-bold">
+        <span className="text-2xl opacity-80">{question.icon}</span>
+        {question.text}
+      </h2>
+      <div className="flex flex-col gap-3">
+        {options.map((opt, i) => (
+          <motion.button
+            key={opt}
+            whileTap={{ scale: 0.97 }}
+            onClick={() => onSelect(i + 1)}
+            className={`flex w-full items-center justify-between rounded-full border px-4 py-3 text-left text-sm transition-colors ${
+              answer === i + 1
+                ? "border-red bg-red text-fg"
+                : "border-border bg-transparent"
+            }`}
+          >
+            <span>{opt}</span>
+            {answer === i + 1 && <Check className="h-4 w-4" />}
+          </motion.button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/ResultChart.tsx
+++ b/src/components/ResultChart.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  ResponsiveContainer,
+  Tooltip,
+} from "recharts";
+
+export default function ResultChart({ data }: { data: { name: string; value: number }[] }) {
+  return (
+    <div className="h-64 w-full">
+      <ResponsiveContainer width="100%" height="100%">
+        <BarChart data={data} layout="vertical">
+          <XAxis type="number" domain={[0, 100]} hide />
+          <YAxis type="category" dataKey="name" width={120} />
+          <Tooltip cursor={{ fill: "transparent" }} />
+          <Bar dataKey="value" fill="var(--red)" isAnimationActive />
+        </BarChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,0 +1,14 @@
+import Link from "next/link";
+
+export default function Sidebar() {
+  return (
+    <aside className="fixed left-0 top-0 z-40 hidden h-full w-16 items-center justify-center border-r border-border bg-bg sm:flex">
+      <Link
+        href="/"
+        className="text-sm font-bold [writing-mode:vertical-rl] rotate-180"
+      >
+        Affinity
+      </Link>
+    </aside>
+  );
+}

--- a/src/components/Skeleton.tsx
+++ b/src/components/Skeleton.tsx
@@ -1,0 +1,3 @@
+export default function Skeleton({ className = "" }: { className?: string }) {
+  return <div className={`animate-pulse rounded-md bg-border ${className}`} />;
+}

--- a/src/components/Toast.tsx
+++ b/src/components/Toast.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { AnimatePresence, motion } from "framer-motion";
+import { ReactNode } from "react";
+
+export default function Toast({
+  show,
+  children,
+}: {
+  show: boolean;
+  children: ReactNode;
+}) {
+  return (
+    <AnimatePresence>
+      {show && (
+        <motion.div
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          exit={{ opacity: 0, y: 20 }}
+          className="fixed bottom-4 left-1/2 z-50 -translate-x-1/2 rounded-md bg-border/80 px-4 py-2 text-sm backdrop-blur"
+        >
+          {children}
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,0 +1,30 @@
+import type { Config } from "tailwindcss";
+
+const config: Config = {
+  content: [
+    "./src/pages/**/*.{js,ts,jsx,tsx,mdx}",
+    "./src/components/**/*.{js,ts,jsx,tsx,mdx}",
+    "./src/app/**/*.{js,ts,jsx,tsx,mdx}",
+  ],
+  theme: {
+    extend: {
+      colors: {
+        bg: "var(--bg)",
+        fg: "var(--fg)",
+        border: "var(--border)",
+        red: {
+          DEFAULT: "var(--red)",
+          dim: "var(--red-dim)",
+        },
+      },
+      fontFamily: {
+        sans: ["var(--font-inter)", "sans-serif"],
+      },
+      maxWidth: {
+        container: "1200px",
+      },
+    },
+  },
+  plugins: [],
+};
+export default config;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,26 @@
+{
+  "compilerOptions": {
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- update landing hero with headline, subtitle, badge and extended CTA
- tweak header spacing and CTA glow
- add question icons, testimonial blurbs and sidebar

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ae344a3ee48328a889eba5d7f0edf7