### PR TITLE
Adjust hero layout spacing and typography

### DIFF
--- a/src/app/checkout/page.tsx
+++ b/src/app/checkout/page.tsx
@@ -5,6 +5,7 @@ import PageTransition from "@/components/PageTransition";
 import Container from "@/components/Container";
 import Skeleton from "@/components/Skeleton";
 import { waitGumroadReady } from "@/lib/gumroad";
+import CheckoutParticles from "@/components/CheckoutParticles";
 
 export default function CheckoutPage() {
   const [product, setProduct] = useState<string | null>(null);
@@ -78,8 +79,9 @@ export default function CheckoutPage() {
               className="relative w-full overflow-hidden rounded-3xl border border-white/10 bg-black/20 shadow-[0_35px_120px_rgba(0,0,0,0.45)]"
               style={frameStyle}
             >
+              <CheckoutParticles />
               {!loaded && (
-                <div className="absolute inset-0">
+                <div className="absolute inset-0 z-10">
                   <Skeleton className="h-full w-full rounded-none" />
                 </div>
               )}
@@ -89,7 +91,7 @@ export default function CheckoutPage() {
                 src={src}
                 title="Gumroad Checkout"
                 loading="lazy"
-                className="h-full w-full"
+                className="relative z-10 h-full w-full"
                 onLoad={() => setLoaded(true)}
               />
             </div>

--- a/src/app/checkout/page.tsx
+++ b/src/app/checkout/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { type CSSProperties, useEffect, useRef, useState } from "react";
 import PageTransition from "@/components/PageTransition";
 import Container from "@/components/Container";
 import Skeleton from "@/components/Skeleton";
@@ -53,34 +53,47 @@ export default function CheckoutPage() {
     ? product
     : `${product}${product.includes("?") ? "&" : "?"}embedded=1`;
 
+  const frameStyle: CSSProperties = { height: "clamp(420px, 80vh, 900px)" };
+
   return (
     <PageTransition>
-      <section className="py-12">
-        <Container className="max-w-[740px]">
-          {!loaded && <Skeleton className="h-[720px] w-full" />}
-          {showLink && !loaded && (
-            <p className="mb-4 text-center text-sm">
-              Se non vedi il checkout, {" "}
-              <a
-                href={product}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="underline"
-              >
-                apri qui
-              </a>
-              .
-            </p>
-          )}
-          <iframe
-            key={src}
-            ref={iframeRef}
-            src={src}
-            className="h-[720px] w-full"
-            title="Gumroad Checkout"
-            loading="lazy"
-            onLoad={() => setLoaded(true)}
-          />
+      <section className="py-12 sm:py-14">
+        <Container className="!max-w-none !px-0 sm:!px-6">
+          <div className="mx-auto flex w-full max-w-screen-xl flex-col gap-6 px-4 sm:gap-8 sm:px-6">
+            {showLink && !loaded && (
+              <p className="text-center text-sm text-muted">
+                Se non vedi il checkout, {" "}
+                <a
+                  href={product}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="underline"
+                >
+                  apri qui
+                </a>
+                .
+              </p>
+            )}
+            <div
+              className="relative w-full overflow-hidden rounded-3xl border border-white/10 bg-black/20 shadow-[0_35px_120px_rgba(0,0,0,0.45)]"
+              style={frameStyle}
+            >
+              {!loaded && (
+                <div className="absolute inset-0">
+                  <Skeleton className="h-full w-full rounded-none" />
+                </div>
+              )}
+              <iframe
+                key={src}
+                ref={iframeRef}
+                src={src}
+                title="Gumroad Checkout"
+                loading="lazy"
+                className="h-full w-full"
+                onLoad={() => setLoaded(true)}
+              />
+            </div>
+          </div>
         </Container>
       </section>
     </PageTransition>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -36,10 +36,12 @@ export default function RootLayout({
       lang="it"
       className={`${poppins.variable} ${jakarta.variable} ${roboto.variable}`}
     >
-      <body className="bg-bg text-fg antialiased">
+      <body className="bg-bg text-fg antialiased overflow-x-hidden">
         <AnimatedBackground />
         <Header />
-        <main className="pt-16 min-h-[calc(100vh-4rem)]">{children}</main>
+        <main className="pt-16 min-h-[calc(100vh-4rem)] overflow-x-hidden">
+          {children}
+        </main>
         <SiteFooter />
       </body>
     </html>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -9,25 +9,31 @@ import FAQSection from "@/components/FAQSection";
 import FinalCTA from "@/components/FinalCTA";
 import StickyCTABar from "@/components/StickyCTABar";
 import SectionSeparator from "@/components/SectionSeparator";
+import HomeParticles from "@/components/HomeParticles";
 
 export default function Home() {
   return (
-    <PageTransition>
-      <HeroSection />
-      <MiniBenefits />
-      <SectionSeparator />
-      <HowItWorks />
-      <SectionSeparator />
-      <ProsConsSection />
-      <SectionSeparator />
-      <AgainstGurus />
-      <SectionSeparator />
-      <Manifesto />
-      <SectionSeparator />
-      <FAQSection />
-      <SectionSeparator />
-      <FinalCTA />
-      <StickyCTABar />
-    </PageTransition>
+    <div className="relative isolate">
+      <HomeParticles />
+      <PageTransition>
+        <div className="relative z-10">
+          <HeroSection />
+          <MiniBenefits />
+          <SectionSeparator />
+          <HowItWorks />
+          <SectionSeparator />
+          <ProsConsSection />
+          <SectionSeparator />
+          <AgainstGurus />
+          <SectionSeparator />
+          <Manifesto />
+          <SectionSeparator />
+          <FAQSection />
+          <SectionSeparator />
+          <FinalCTA />
+          <StickyCTABar />
+        </div>
+      </PageTransition>
+    </div>
   );
 }

--- a/src/components/AgainstGurus.tsx
+++ b/src/components/AgainstGurus.tsx
@@ -13,7 +13,7 @@ export default function AgainstGurus() {
   } as const;
 
   return (
-    <motion.section className="py-12 sm:py-16 lg:py-20" {...sectionProps}>
+    <motion.section className="py-10 sm:py-14" {...sectionProps}>
       <Container className="flex justify-center">
         <div className="relative max-w-5xl overflow-hidden rounded-3xl border border-red/40 bg-white/5 p-8 sm:p-10 backdrop-blur-md">
           <BadgeDollarSign className="mx-auto mb-6 h-8 w-8 text-white/80" />

--- a/src/components/CheckoutParticles.tsx
+++ b/src/components/CheckoutParticles.tsx
@@ -56,12 +56,12 @@ const desktopOptions = {
       enable: true,
       distance: 150,
       color: "#ffffff",
-      opacity: 0.4,
+      opacity: 0.3,
       width: 1,
     },
     move: {
       enable: true,
-      speed: 6,
+      speed: 1.6,
       direction: "none",
       random: false,
       straight: false,
@@ -126,7 +126,7 @@ const mobileOptions = {
     },
     move: {
       ...desktopOptions.particles.move,
-      speed: 4,
+      speed: 0.9,
     },
   },
 };

--- a/src/components/CheckoutParticles.tsx
+++ b/src/components/CheckoutParticles.tsx
@@ -1,0 +1,162 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import Particles from "react-tsparticles";
+import type { Engine } from "tsparticles-engine";
+import { loadFull } from "tsparticles";
+
+const desktopOptions = {
+  particles: {
+    number: {
+      value: 80,
+      density: {
+        enable: true,
+        value_area: 800,
+      },
+    },
+    color: {
+      value: "#ffffff",
+    },
+    shape: {
+      type: "circle",
+      stroke: {
+        width: 0,
+        color: "#000000",
+      },
+      polygon: {
+        nb_sides: 5,
+      },
+      image: {
+        src: "img/github.svg",
+        width: 100,
+        height: 100,
+      },
+    },
+    opacity: {
+      value: 0.5,
+      random: false,
+      anim: {
+        enable: false,
+        speed: 1,
+        opacity_min: 0.1,
+        sync: false,
+      },
+    },
+    size: {
+      value: 3,
+      random: true,
+      anim: {
+        enable: false,
+        speed: 40,
+        size_min: 0.1,
+        sync: false,
+      },
+    },
+    line_linked: {
+      enable: true,
+      distance: 150,
+      color: "#ffffff",
+      opacity: 0.4,
+      width: 1,
+    },
+    move: {
+      enable: true,
+      speed: 6,
+      direction: "none",
+      random: false,
+      straight: false,
+      out_mode: "out",
+      bounce: false,
+      attract: {
+        enable: false,
+        rotateX: 600,
+        rotateY: 1200,
+      },
+    },
+  },
+  interactivity: {
+    detect_on: "canvas",
+    events: {
+      onhover: {
+        enable: true,
+        mode: "repulse",
+      },
+      onclick: {
+        enable: true,
+        mode: "push",
+      },
+      resize: true,
+    },
+    modes: {
+      grab: {
+        distance: 400,
+        line_linked: {
+          opacity: 1,
+        },
+      },
+      bubble: {
+        distance: 400,
+        size: 40,
+        duration: 2,
+        opacity: 8,
+        speed: 3,
+      },
+      repulse: {
+        distance: 200,
+        duration: 0.4,
+      },
+      push: {
+        particles_nb: 4,
+      },
+      remove: {
+        particles_nb: 2,
+      },
+    },
+  },
+  retina_detect: true,
+};
+
+const mobileOptions = {
+  ...desktopOptions,
+  particles: {
+    ...desktopOptions.particles,
+    number: {
+      ...desktopOptions.particles.number,
+      value: 50,
+    },
+    move: {
+      ...desktopOptions.particles.move,
+      speed: 4,
+    },
+  },
+};
+
+export default function CheckoutParticles() {
+  const [options, setOptions] = useState(desktopOptions);
+
+  useEffect(() => {
+    const update = () => {
+      setOptions(window.innerWidth < 768 ? mobileOptions : desktopOptions);
+    };
+
+    update();
+    window.addEventListener("resize", update);
+
+    return () => window.removeEventListener("resize", update);
+  }, []);
+
+  const init = useCallback(async (engine: Engine) => {
+    await loadFull(engine);
+  }, []);
+
+  return (
+    <Particles
+      id="checkout-particles"
+      init={init}
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      options={options as any}
+      className="pointer-events-none absolute inset-0 z-0"
+    />
+  );
+}
+

--- a/src/components/CheckoutParticles.tsx
+++ b/src/components/CheckoutParticles.tsx
@@ -33,7 +33,7 @@ const desktopOptions = {
       },
     },
     opacity: {
-      value: 0.5,
+      value: 0.3,
       random: false,
       anim: {
         enable: false,
@@ -56,7 +56,7 @@ const desktopOptions = {
       enable: true,
       distance: 150,
       color: "#ffffff",
-      opacity: 0.3,
+      opacity: 0.15,
       width: 1,
     },
     move: {

--- a/src/components/FAQSection.tsx
+++ b/src/components/FAQSection.tsx
@@ -37,7 +37,7 @@ export default function FAQSection() {
     transition: { duration: 0.6 },
   } as const;
   return (
-    <motion.section id="faq" className="py-12 sm:py-16 lg:py-20" {...sectionProps}>
+    <motion.section id="faq" className="py-10 sm:py-14" {...sectionProps}>
       <Container>
         <h2 className="text-center font-heading font-extrabold tracking-[-0.5px] text-3xl">Domande frequenti</h2>
         <div className="mx-auto mt-8 max-w-3xl space-y-4">

--- a/src/components/FinalCTA.tsx
+++ b/src/components/FinalCTA.tsx
@@ -12,7 +12,7 @@ export default function FinalCTA() {
     transition: { duration: 0.6 },
   } as const;
   return (
-    <motion.section className="py-12 sm:py-16 lg:py-20 text-center" {...sectionProps}>
+    <motion.section className="py-10 sm:py-14 text-center" {...sectionProps}>
       <Container>
         <h2 className="font-heading font-extrabold tracking-[-0.5px] text-3xl">Pronto a iniziare?</h2>
         <CTAButton href="/test" className="mt-8 px-8 py-4">

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -33,14 +33,21 @@ export default function Header() {
             Affinity
           </Link>
         )}
-        <nav className="ml-auto flex items-center gap-4 pl-4 text-xs font-jakarta sm:gap-6 sm:text-sm">
-          <Link href="/#come-funziona" className="hover:text-red whitespace-nowrap">
-            Come funziona
-          </Link>
-          <Link href="/privacy" className="hover:text-red">
-            Privacy
-          </Link>
-          <CTAButton href="/test">Inizia</CTAButton>
+        <nav className="ml-auto flex items-center gap-3">
+          <div className="hidden items-center gap-4 text-xs font-jakarta sm:flex sm:text-sm">
+            <Link href="/#come-funziona" className="hover:text-red whitespace-nowrap">
+              Come funziona
+            </Link>
+            <Link href="/privacy" className="hover:text-red">
+              Privacy
+            </Link>
+          </div>
+          <CTAButton
+            href="/test"
+            className="ml-2 max-w-full !px-4 !py-2 text-xs sm:ml-4 sm:text-sm"
+          >
+            Inizia
+          </CTAButton>
         </nav>
       </div>
       <div className="pointer-events-none absolute inset-x-0 bottom-0 h-px bg-gradient-to-r from-transparent via-red/60 to-transparent" />

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -33,8 +33,8 @@ export default function Header() {
             Affinity
           </Link>
         )}
-        <nav className="ml-auto flex items-center gap-6 text-sm font-jakarta">
-          <Link href="/#come-funziona" className="hover:text-red">
+        <nav className="ml-auto flex items-center gap-4 pl-4 text-xs font-jakarta sm:gap-6 sm:text-sm">
+          <Link href="/#come-funziona" className="hover:text-red whitespace-nowrap">
             Come funziona
           </Link>
           <Link href="/privacy" className="hover:text-red">

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -8,7 +8,7 @@ import { motion } from "framer-motion";
 export default function HeroSection() {
   return (
     <section className="relative flex h-[calc(100vh-4rem)] items-center">
-      <Container className="flex flex-col items-center justify-center px-6 sm:px-8 text-center -translate-y-6 md:-translate-y-12 pt-2 pb-8 sm:pb-10">
+      <Container className="flex flex-col items-center justify-center px-6 sm:px-8 text-center -translate-y-2 md:-translate-y-6 pt-2 pb-8 sm:pb-10">
         <div className="flex flex-col items-center">
           <div className="rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs font-jakarta text-white/90 backdrop-blur">
             +20.000 persone hanno già fatto il test
@@ -17,7 +17,7 @@ export default function HeroSection() {
             initial={{ opacity: 0, y: 20 }}
             animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.6 }}
-            className="mx-auto mt-4 max-w-[24ch] md:max-w-[36ch] font-heading font-extrabold tracking-[-0.5px] text-[clamp(2rem,5vw,3.5rem)] leading-tight hyphens-auto break-words text-balance"
+            className="mx-auto mt-4 max-w-[24ch] md:max-w-[36ch] font-heading font-extrabold tracking-[-0.5px] text-[clamp(2.35rem,6vw,4rem)] leading-tight hyphens-auto break-words text-balance"
           >
             Scopri perché le tue
             <br />
@@ -27,7 +27,7 @@ export default function HeroSection() {
             initial={{ opacity: 0, y: 20 }}
             animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.6, delay: 0.2 }}
-            className="mx-auto mt-7 max-w-[60ch] text-muted text-balance"
+            className="mx-auto mt-7 max-w-[60ch] text-lg sm:text-xl md:text-[1.35rem] leading-relaxed text-muted text-balance"
           >
             Un test gratuito in 5 minuti che ti apre gli occhi. E una guida basata su 500+ studi per cambiare davvero.
           </motion.p>

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -8,7 +8,7 @@ import { motion } from "framer-motion";
 export default function HeroSection() {
   return (
     <section className="relative flex h-[calc(100vh-4rem)] items-center">
-      <Container className="flex flex-col items-center justify-center px-6 sm:px-8 text-center -translate-y-2 md:-translate-y-6 pt-2 pb-8 sm:pb-10">
+      <Container className="flex flex-col items-center justify-center px-5 sm:px-8 text-center -translate-y-1 md:-translate-y-6 pt-4 pb-8 sm:pb-10">
         <div className="flex flex-col items-center">
           <div className="rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs font-jakarta text-white/90 backdrop-blur">
             +20.000 persone hanno già fatto il test
@@ -17,7 +17,7 @@ export default function HeroSection() {
             initial={{ opacity: 0, y: 20 }}
             animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.6 }}
-            className="mx-auto mt-4 max-w-[24ch] md:max-w-[36ch] font-heading font-extrabold tracking-[-0.5px] text-[clamp(2.35rem,6vw,4rem)] leading-tight hyphens-auto break-words text-balance"
+            className="mx-auto mt-4 max-w-[22ch] sm:max-w-[32ch] md:max-w-[36ch] font-heading font-extrabold tracking-[-0.5px] text-[clamp(2rem,6.5vw,4rem)] leading-tight hyphens-auto break-words text-balance"
           >
             Scopri perché le tue
             <br />
@@ -27,7 +27,7 @@ export default function HeroSection() {
             initial={{ opacity: 0, y: 20 }}
             animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.6, delay: 0.2 }}
-            className="mx-auto mt-7 max-w-[60ch] text-lg sm:text-xl md:text-[1.35rem] leading-relaxed text-muted text-balance"
+            className="mx-auto mt-6 max-w-[60ch] text-[clamp(1.05rem,4vw,1.35rem)] leading-relaxed text-muted text-balance"
           >
             Un test gratuito in 5 minuti che ti apre gli occhi. E una guida basata su 500+ studi per cambiare davvero.
           </motion.p>

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -4,18 +4,22 @@ import CTAButton from "@/components/CTAButton";
 import HeroTicker from "@/components/HeroTicker";
 import { motion } from "framer-motion";
 
+const reduce =
+  typeof window !== "undefined" &&
+  window.matchMedia?.("(prefers-reduced-motion: reduce)").matches;
+
 export default function HeroSection() {
   return (
-    <section className="relative flex min-h-[calc(100vh-4rem)] items-center">
-      <div className="mx-auto flex w-full max-w-screen-lg flex-col items-center justify-center px-4 pt-6 pb-10 text-center sm:px-6">
+    <section className="relative flex min-h-[calc(100vh-4rem)] items-start">
+      <div className="mx-auto flex w-full max-w-screen-lg flex-col items-center justify-start px-4 pt-8 pb-8 text-center sm:px-6 sm:pt-10 md:pt-14">
         <div className="rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs font-jakarta text-white/90 backdrop-blur">
           +20.000 persone hanno già fatto il test
         </div>
         <motion.h1
           initial={{ opacity: 0, y: 20 }}
           animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.6 }}
-          className="mt-5 font-heading text-[clamp(28px,6vw,48px)] font-extrabold leading-tight tracking-[-0.5px] text-balance break-words sm:text-5xl md:text-6xl"
+          transition={reduce ? { duration: 0 } : { duration: 0.6 }}
+          className="mt-4 font-heading text-[clamp(28px,6vw,48px)] font-extrabold leading-tight tracking-[-0.5px] text-balance break-words sm:text-5xl md:text-6xl"
         >
           Scopri perché le tue
           <br />
@@ -24,16 +28,16 @@ export default function HeroSection() {
         <motion.p
           initial={{ opacity: 0, y: 20 }}
           animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.6, delay: 0.2 }}
-          className="mt-4 text-[clamp(15px,3.8vw,18px)] leading-relaxed text-muted text-pretty break-words hyphens-auto"
+          transition={reduce ? { duration: 0 } : { duration: 0.6, delay: 0.2 }}
+          className="mt-3 text-[clamp(15px,3.8vw,18px)] leading-relaxed text-muted text-pretty break-words hyphens-auto"
         >
           Un test gratuito in 5 minuti che ti apre gli occhi. E una guida basata su 500+ studi per cambiare davvero.
         </motion.p>
         <motion.div
           initial={{ opacity: 0, y: 20 }}
           animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.6, delay: 0.4 }}
-          className="mt-8 w-full sm:mt-10 sm:w-auto"
+          transition={reduce ? { duration: 0 } : { duration: 0.6, delay: 0.4 }}
+          className="mt-6 w-full sm:mt-8 sm:w-auto"
         >
           <CTAButton
             href="/test"
@@ -45,8 +49,8 @@ export default function HeroSection() {
         <motion.div
           initial={{ opacity: 0, y: 20 }}
           animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.6, delay: 0.6 }}
-          className="w-full"
+          transition={reduce ? { duration: 0 } : { duration: 0.6, delay: 0.6 }}
+          className="w-full mt-6 sm:mt-8"
         >
           <HeroTicker />
         </motion.div>

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -1,56 +1,56 @@
 "use client";
 
 import CTAButton from "@/components/CTAButton";
-import Container from "@/components/Container";
 import HeroTicker from "@/components/HeroTicker";
 import { motion } from "framer-motion";
 
 export default function HeroSection() {
   return (
-    <section className="relative flex h-[calc(100vh-4rem)] items-center">
-      <Container className="flex flex-col items-center justify-center px-5 sm:px-8 text-center -translate-y-1 md:-translate-y-6 pt-4 pb-8 sm:pb-10">
-        <div className="flex flex-col items-center">
-          <div className="rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs font-jakarta text-white/90 backdrop-blur">
-            +20.000 persone hanno già fatto il test
-          </div>
-          <motion.h1
-            initial={{ opacity: 0, y: 20 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.6 }}
-            className="mx-auto mt-4 max-w-[22ch] sm:max-w-[32ch] md:max-w-[36ch] font-heading font-extrabold tracking-[-0.5px] text-[clamp(2rem,6.5vw,4rem)] leading-tight hyphens-auto break-words text-balance"
-          >
-            Scopri perché le tue
-            <br />
-            relazioni non funzionano
-          </motion.h1>
-          <motion.p
-            initial={{ opacity: 0, y: 20 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.6, delay: 0.2 }}
-            className="mx-auto mt-6 max-w-[60ch] text-[clamp(1.05rem,4vw,1.35rem)] leading-relaxed text-muted text-balance"
-          >
-            Un test gratuito in 5 minuti che ti apre gli occhi. E una guida basata su 500+ studi per cambiare davvero.
-          </motion.p>
-          <motion.div
-            initial={{ opacity: 0, y: 20 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.6, delay: 0.4 }}
-            className="mt-10"
-          >
-            <CTAButton href="/test" className="px-10 py-5 text-lg">
-              Inizia il test gratuito
-            </CTAButton>
-          </motion.div>
-          <motion.div
-            initial={{ opacity: 0, y: 20 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.6, delay: 0.6 }}
-            className="w-full"
-          >
-            <HeroTicker />
-          </motion.div>
+    <section className="relative flex min-h-[calc(100vh-4rem)] items-center">
+      <div className="mx-auto flex w-full max-w-screen-lg flex-col items-center justify-center px-4 pt-6 pb-10 text-center sm:px-6">
+        <div className="rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs font-jakarta text-white/90 backdrop-blur">
+          +20.000 persone hanno già fatto il test
         </div>
-      </Container>
+        <motion.h1
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.6 }}
+          className="mt-5 font-heading text-[clamp(28px,6vw,48px)] font-extrabold leading-tight tracking-[-0.5px] text-balance break-words sm:text-5xl md:text-6xl"
+        >
+          Scopri perché le tue
+          <br />
+          relazioni non funzionano
+        </motion.h1>
+        <motion.p
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.6, delay: 0.2 }}
+          className="mt-4 text-[clamp(15px,3.8vw,18px)] leading-relaxed text-muted text-pretty break-words hyphens-auto"
+        >
+          Un test gratuito in 5 minuti che ti apre gli occhi. E una guida basata su 500+ studi per cambiare davvero.
+        </motion.p>
+        <motion.div
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.6, delay: 0.4 }}
+          className="mt-8 w-full sm:mt-10 sm:w-auto"
+        >
+          <CTAButton
+            href="/test"
+            className="w-full max-w-full !flex justify-center !px-5 !py-3 text-base sm:w-auto sm:!px-6 sm:!py-3 sm:text-lg"
+          >
+            Inizia il test gratuito
+          </CTAButton>
+        </motion.div>
+        <motion.div
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.6, delay: 0.6 }}
+          className="w-full"
+        >
+          <HeroTicker />
+        </motion.div>
+      </div>
     </section>
   );
 }

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -11,7 +11,7 @@ const reduce =
 export default function HeroSection() {
   return (
     <section className="relative flex min-h-[calc(100vh-4rem)] items-start">
-      <div className="mx-auto flex w-full max-w-screen-lg flex-col items-center justify-start px-4 pt-8 pb-8 text-center sm:px-6 sm:pt-10 md:pt-14">
+      <div className="mx-auto flex w-full max-w-screen-lg flex-col items-center justify-start px-4 pt-8 pb-4 text-center sm:px-6 sm:pt-10 md:pt-14">
         <div className="rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs font-jakarta text-white/90 backdrop-blur">
           +20.000 persone hanno già fatto il test
         </div>

--- a/src/components/HeroTicker.tsx
+++ b/src/components/HeroTicker.tsx
@@ -22,8 +22,8 @@ const track = [...half, ...half];
 export default function HeroTicker() {
   return (
     <div
-      className="group relative mt-20 w-full overflow-hidden"
-      style={{ "--marquee-duration": "45s" } as CSSProperties}
+      className="group relative mt-24 sm:mt-28 lg:mt-32 xl:mt-36 w-full overflow-hidden"
+      style={{ "--marquee-duration": "60s" } as CSSProperties}
     >
       <div
         className="

--- a/src/components/HeroTicker.tsx
+++ b/src/components/HeroTicker.tsx
@@ -22,20 +22,20 @@ const track = [...half, ...half];
 export default function HeroTicker() {
   return (
     <div
-      className="group relative mt-24 sm:mt-28 lg:mt-32 xl:mt-36 w-full overflow-hidden"
+      className="group relative mt-24 w-full overflow-hidden px-4 sm:mt-28 sm:px-0 lg:mt-32 xl:mt-36"
       style={{ "--marquee-duration": "60s" } as CSSProperties}
     >
       <div
         className="
           flex w-max animate-marquee select-none whitespace-nowrap
-          gap-4 motion-reduce:animate-none group-hover:[animation-play-state:paused]
+          gap-3 motion-reduce:animate-none group-hover:[animation-play-state:paused] sm:gap-4
         "
       >
         {track.map((item, idx) => (
           <div
             key={`${item.label}-${idx}`}
             className="
-              pointer-events-none inline-flex items-center gap-2
+              pointer-events-none inline-flex shrink-0 items-center gap-2
               whitespace-nowrap rounded-full border border-white/10
               bg-black/20 px-4 py-2 text-sm font-jakarta text-white/90 shadow-sm
             "

--- a/src/components/HomeParticles.tsx
+++ b/src/components/HomeParticles.tsx
@@ -1,0 +1,161 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import Particles from "react-tsparticles";
+import type { Engine } from "tsparticles-engine";
+import { loadFull } from "tsparticles";
+
+const desktopOptions = {
+  particles: {
+    number: {
+      value: 80,
+      density: {
+        enable: true,
+        value_area: 800,
+      },
+    },
+    color: {
+      value: "#ffffff",
+    },
+    shape: {
+      type: "circle",
+      stroke: {
+        width: 0,
+        color: "#000000",
+      },
+      polygon: {
+        nb_sides: 5,
+      },
+      image: {
+        src: "img/github.svg",
+        width: 100,
+        height: 100,
+      },
+    },
+    opacity: {
+      value: 0.3,
+      random: false,
+      anim: {
+        enable: false,
+        speed: 1,
+        opacity_min: 0.1,
+        sync: false,
+      },
+    },
+    size: {
+      value: 3,
+      random: true,
+      anim: {
+        enable: false,
+        speed: 40,
+        size_min: 0.1,
+        sync: false,
+      },
+    },
+    line_linked: {
+      enable: true,
+      distance: 150,
+      color: "#ffffff",
+      opacity: 0.2,
+      width: 1,
+    },
+    move: {
+      enable: true,
+      speed: 1,
+      direction: "none",
+      random: false,
+      straight: false,
+      out_mode: "out",
+      bounce: false,
+      attract: {
+        enable: false,
+        rotateX: 600,
+        rotateY: 1200,
+      },
+    },
+  },
+  interactivity: {
+    detect_on: "canvas",
+    events: {
+      onhover: {
+        enable: true,
+        mode: "repulse",
+      },
+      onclick: {
+        enable: true,
+        mode: "push",
+      },
+      resize: true,
+    },
+    modes: {
+      grab: {
+        distance: 400,
+        line_linked: {
+          opacity: 1,
+        },
+      },
+      bubble: {
+        distance: 400,
+        size: 40,
+        duration: 2,
+        opacity: 8,
+        speed: 3,
+      },
+      repulse: {
+        distance: 200,
+        duration: 0.4,
+      },
+      push: {
+        particles_nb: 4,
+      },
+      remove: {
+        particles_nb: 2,
+      },
+    },
+  },
+  retina_detect: true,
+};
+
+const mobileOptions = {
+  ...desktopOptions,
+  particles: {
+    ...desktopOptions.particles,
+    number: {
+      ...desktopOptions.particles.number,
+      value: 55,
+    },
+    move: {
+      ...desktopOptions.particles.move,
+      speed: 0.6,
+    },
+  },
+};
+
+export default function HomeParticles() {
+  const [options, setOptions] = useState(desktopOptions);
+
+  useEffect(() => {
+    const update = () => {
+      setOptions(window.innerWidth < 768 ? mobileOptions : desktopOptions);
+    };
+
+    update();
+    window.addEventListener("resize", update);
+
+    return () => window.removeEventListener("resize", update);
+  }, []);
+
+  const init = useCallback(async (engine: Engine) => {
+    await loadFull(engine);
+  }, []);
+
+  return (
+    <Particles
+      id="home-particles"
+      init={init}
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      options={options as any}
+      className="pointer-events-none absolute inset-0 -z-10"
+    />
+  );
+}

--- a/src/components/HomeParticles.tsx
+++ b/src/components/HomeParticles.tsx
@@ -33,7 +33,7 @@ const desktopOptions = {
       },
     },
     opacity: {
-      value: 0.3,
+      value: 0.1,
       random: false,
       anim: {
         enable: false,
@@ -56,7 +56,7 @@ const desktopOptions = {
       enable: true,
       distance: 150,
       color: "#ffffff",
-      opacity: 0.2,
+      opacity: 0.1,
       width: 1,
     },
     move: {

--- a/src/components/HowItWorks.tsx
+++ b/src/components/HowItWorks.tsx
@@ -14,7 +14,7 @@ export default function HowItWorks() {
   const card =
     "relative rounded-2xl border border-[#333] bg-white/5 p-6 text-center backdrop-blur-sm shadow-lg shadow-black/20 transition-transform hover:-translate-y-1 hover:shadow-xl hover:shadow-black/30";
   return (
-    <motion.section id="come-funziona" className="py-12 sm:py-16 lg:py-20" {...sectionProps}>
+    <motion.section id="come-funziona" className="py-10 sm:py-14" {...sectionProps}>
       <Container className="text-center">
         <h2 className="font-heading font-extrabold tracking-[-0.5px] text-3xl">Come funziona Affinity?</h2>
         <p className="mx-auto mt-4 max-w-2xl text-muted">

--- a/src/components/Manifesto.tsx
+++ b/src/components/Manifesto.tsx
@@ -13,7 +13,7 @@ export default function Manifesto() {
   } as const;
 
   return (
-    <motion.section className="py-12 sm:py-16" {...sectionProps}>
+    <motion.section className="py-10 sm:py-14" {...sectionProps}>
       <Container className="flex justify-center">
         <div className="relative max-w-5xl overflow-hidden rounded-3xl border border-red/40 bg-white/5 p-8 sm:p-10 text-center backdrop-blur-md">
           <Heart className="mx-auto mb-6 h-8 w-8 text-white/80" />

--- a/src/components/MiniBenefits.tsx
+++ b/src/components/MiniBenefits.tsx
@@ -4,6 +4,10 @@ import Container from "@/components/Container";
 import { Search, Hourglass, Zap } from "lucide-react";
 import { motion } from "framer-motion";
 
+const reduce =
+  typeof window !== "undefined" &&
+  window.matchMedia?.("(prefers-reduced-motion: reduce)").matches;
+
 const items = [
   {
     icon: Search,
@@ -26,20 +30,24 @@ export default function MiniBenefits() {
   const container = {
     hidden: {},
     show: {
-      transition: { staggerChildren: 0.06 },
+      transition: reduce ? { staggerChildren: 0 } : { staggerChildren: 0.06 },
     },
   } as const;
 
   const item = {
     hidden: { opacity: 0, y: 20 },
-    show: { opacity: 1, y: 0, transition: { duration: 0.6 } },
+    show: {
+      opacity: 1,
+      y: 0,
+      transition: reduce ? { duration: 0 } : { duration: 0.6 },
+    },
   } as const;
 
 const baseCard =
   "flex flex-col gap-4 rounded-2xl border-2 border-red/50 bg-black/20 p-6 transition hover:shadow-[0_0_20px_rgba(229,9,20,0.35)]";
 
   return (
-    <section className="pt-6 pb-12 sm:pt-10 sm:pb-16">
+    <section className="pt-3 pb-12 sm:pt-6 sm:pb-16">
       <Container>
         <motion.div
           variants={container}
@@ -53,7 +61,7 @@ const baseCard =
               key={title}
               variants={item}
               className={`${baseCard} ${
-                i === 2 ? "md:col-span-2 md:max-w-md md:mx-auto" : ""
+                i === 2 ? "md:col-span-2 md:max-w-2xl md:mx-auto" : ""
               }`}
             >
               <Icon className="h-10 w-10 text-white/80" />

--- a/src/components/MiniBenefits.tsx
+++ b/src/components/MiniBenefits.tsx
@@ -47,7 +47,7 @@ const baseCard =
   "flex flex-col gap-4 rounded-2xl border-2 border-red/50 bg-black/20 p-6 transition hover:shadow-[0_0_20px_rgba(229,9,20,0.35)]";
 
   return (
-    <section className="pt-0 pb-12 sm:pt-2 sm:pb-16">
+    <section className="pt-0 pb-12 sm:pt-2 sm:pb-14">
       <Container>
         <motion.div
           variants={container}

--- a/src/components/MiniBenefits.tsx
+++ b/src/components/MiniBenefits.tsx
@@ -39,7 +39,7 @@ const baseCard =
   "flex flex-col gap-4 rounded-2xl border-2 border-red/50 bg-black/20 p-6 transition hover:shadow-[0_0_20px_rgba(229,9,20,0.35)]";
 
   return (
-    <section className="py-12 sm:py-16">
+    <section className="pt-6 pb-12 sm:pt-10 sm:pb-16">
       <Container>
         <motion.div
           variants={container}

--- a/src/components/MiniBenefits.tsx
+++ b/src/components/MiniBenefits.tsx
@@ -47,7 +47,7 @@ const baseCard =
   "flex flex-col gap-4 rounded-2xl border-2 border-red/50 bg-black/20 p-6 transition hover:shadow-[0_0_20px_rgba(229,9,20,0.35)]";
 
   return (
-    <section className="pt-3 pb-12 sm:pt-6 sm:pb-16">
+    <section className="pt-0 pb-12 sm:pt-2 sm:pb-16">
       <Container>
         <motion.div
           variants={container}

--- a/src/components/ProsConsSection.tsx
+++ b/src/components/ProsConsSection.tsx
@@ -14,7 +14,7 @@ export default function ProsConsSection() {
   const card =
     "relative overflow-hidden rounded-2xl border border-[#333] bg-white/5 p-8 md:p-6 text-center md:text-left backdrop-blur-sm transition-transform hover:-translate-y-1";
   return (
-    <motion.section id="perche-affinity" className="py-12 sm:py-16 lg:py-20" {...sectionProps}>
+    <motion.section id="perche-affinity" className="py-10 sm:py-14" {...sectionProps}>
       <Container className="text-center">
         <h2 className="font-heading font-extrabold tracking-[-0.5px] text-3xl">Perché Affinity è diverso da tutto il resto</h2>
         <p className="mx-auto mt-4 max-w-2xl text-muted">

--- a/src/components/StickyCTABar.tsx
+++ b/src/components/StickyCTABar.tsx
@@ -4,10 +4,15 @@ import CTAButton from "@/components/CTAButton";
 
 export default function StickyCTABar() {
   return (
-    <div className="fixed bottom-0 left-0 right-0 z-30 bg-bg/80 px-4 py-3 backdrop-blur md:hidden">
-      <CTAButton href="/test" className="w-full py-3">
-        Inizia gratis
-      </CTAButton>
+    <div className="fixed inset-x-4 bottom-4 z-40 md:hidden sm:inset-x-6 sm:bottom-6">
+      <div className="mx-auto w-full max-w-screen-sm rounded-2xl bg-bg/80 px-4 py-3 shadow-lg shadow-black/30 backdrop-blur sm:max-w-screen-md">
+        <CTAButton
+          href="/test"
+          className="w-full max-w-full !flex justify-center !px-5 !py-3 text-base"
+        >
+          Inizia gratis
+        </CTAButton>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- enlarge the hero headline and subtitle for improved readability across breakpoints
- drop and slow the hero ticker so it sits lower in the fold with a gentler scroll
- raise the mini benefit cards by tightening only the section’s top padding to reduce dead space while keeping lower spacing intact

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cc4a523c5083288f98dd04fe95adeb