### PR TITLE
Load hero image from provided Google Drive asset

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,4 +1,14 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+  images: {
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "drive.google.com",
+        pathname: "/uc",
+      },
+    ],
+  },
+};
 
 export default nextConfig;

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -23,7 +23,7 @@ export default function Header() {
         scrolled ? "shadow-lg shadow-black/40" : ""
       }`}
     >
-      <div className="flex h-16 items-center px-4">
+      <div className="flex h-8 items-center px-4">
         {pathname === "/checkout" ? (
           <a href="/" className="text-2xl font-heading font-bold tracking-[-0.5px]">
             Affinity

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Image from "next/image";
 import CTAButton from "@/components/CTAButton";
 import HeroTicker from "@/components/HeroTicker";
 import { motion } from "framer-motion";
@@ -10,7 +11,17 @@ const reduce =
 
 export default function HeroSection() {
   return (
-    <section className="relative flex min-h-[calc(100vh-4rem)] lg:min-h-0 items-start">
+    <section className="relative flex min-h-[calc(100vh-4rem)] lg:min-h-0 items-start overflow-hidden">
+      <div className="absolute inset-0 -z-10">
+        <Image
+          src="https://drive.google.com/uc?id=1bXO7FfzLd42V7EqNhhPG8kYuZ5ih5edr"
+          alt="Coppia che cammina insieme tenendosi per mano"
+          fill
+          priority
+          className="object-cover object-center"
+        />
+        <div className="absolute inset-0 bg-gradient-to-b from-bg/60 via-bg/70 to-bg/90" aria-hidden />
+      </div>
       <div className="mx-auto flex w-full max-w-screen-lg flex-col items-center justify-start px-4 pt-8 pb-2 text-center sm:px-6 sm:pt-10 md:pt-14">
         <div className="rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs font-jakarta text-white/90 backdrop-blur">
           +20.000 persone hanno già fatto il test


### PR DESCRIPTION
## Summary
- point the hero background to the Google Drive image supplied by the client
- allow Next.js Image optimization for the drive.google.com host that serves the asset
- slim down the sticky header by halving its height so it no longer covers as much of the hero

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d114bcf3a08328a7a7e007c1c339ec