### PR TITLE
Adjust PageTransition container height

### DIFF
--- a/src/components/PageTransition.tsx
+++ b/src/components/PageTransition.tsx
@@ -9,7 +9,6 @@ export default function PageTransition({ children }: { children: ReactNode }) {
       initial={{ opacity: 0, y: 16 }}
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.2 }}
-      className="h-full"
     >
       {children}
     </motion.div>


### PR DESCRIPTION
## Summary
- remove the fixed h-full class from the page transition wrapper so pages size themselves to their content

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d12f67ad2c8328afc7c509b49eb4da