### PR TITLE
Make header fixed with gradient and hero full-bleed

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -63,7 +63,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
           </noscript>
         ) : null}
         <Header />
-        <main className="min-h-[calc(100vh-4rem)] pt-16 overflow-x-hidden">
+        <main className="min-h-screen overflow-x-hidden">
           {children}
         </main>
         <SiteFooter />

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -19,25 +19,38 @@ export default function Header() {
 
   return (
     <header
-      className={`sticky top-0 z-20 transition-shadow ${
+      className={`fixed top-0 left-0 w-full z-50 transition-all ${
         scrolled
-          ? "bg-bg/80 backdrop-blur shadow-lg shadow-black/40"
+          ? "backdrop-blur bg-bg/70 shadow-lg shadow-black/30"
           : "bg-transparent"
       }`}
     >
-      <div className="flex h-8 items-center px-4">
+      {!scrolled && (
+        <div className="pointer-events-none absolute inset-0 bg-gradient-to-b from-black/60 to-transparent" />
+      )}
+
+      <div className="relative z-10 flex h-12 items-center px-4">
         {pathname === "/checkout" ? (
-          <a href="/" className="text-2xl font-heading font-bold tracking-[-0.5px]">
+          <a
+            href="/"
+            className="text-2xl font-heading font-bold tracking-[-0.5px]"
+          >
             Affinity
           </a>
         ) : (
-          <Link href="/" className="text-2xl font-heading font-bold tracking-[-0.5px]">
+          <Link
+            href="/"
+            className="text-2xl font-heading font-bold tracking-[-0.5px]"
+          >
             Affinity
           </Link>
         )}
         <nav className="ml-auto flex items-center gap-3">
           <div className="hidden items-center gap-4 text-xs font-jakarta sm:flex sm:text-sm">
-            <Link href="/#come-funziona" className="hover:text-red whitespace-nowrap">
+            <Link
+              href="/#come-funziona"
+              className="hover:text-red whitespace-nowrap"
+            >
               Come funziona
             </Link>
             <Link href="/privacy" className="hover:text-red">
@@ -52,6 +65,7 @@ export default function Header() {
           </CTAButton>
         </nav>
       </div>
+
       <div className="pointer-events-none absolute inset-x-0 bottom-0 h-px bg-gradient-to-r from-transparent via-red/60 to-transparent" />
     </header>
   );

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -11,16 +11,23 @@ const reduce =
 
 export default function HeroSection() {
   return (
-    <section className="relative flex min-h-[calc(100vh-4rem)] lg:min-h-0 items-start overflow-hidden">
+    <section className="relative flex min-h-[100vh] items-start overflow-hidden pt-12">
+      {/* Background image */}
       <div className="absolute inset-0 -z-10">
         <Image
+          // Se hai caricato in /public: src="/images/hero.jpg"
+          // Se usi Google Drive: lascia l'URL con uc?export=view&id=
           src="https://drive.google.com/uc?export=view&id=1SzyhjCD5NjNfOp0pOKMluvp0QIiyDVdi"
           alt="Coppia che cammina insieme tenendosi per mano"
           fill
           priority
           className="object-cover object-center"
+          unoptimized
         />
+        {/* Overlay per contrasto del testo */}
+        <div className="absolute inset-0 bg-black/35" />
       </div>
+
       <div className="mx-auto flex w-full max-w-screen-lg flex-col items-center justify-start px-4 pt-8 pb-2 text-center sm:px-6 sm:pt-10 md:pt-14">
         <div className="rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs font-jakarta text-white/90 backdrop-blur">
           +20.000 persone hanno già fatto il test

--- a/src/components/PageTransition.tsx
+++ b/src/components/PageTransition.tsx
@@ -9,7 +9,6 @@ export default function PageTransition({ children }: { children: ReactNode }) {
       initial={{ opacity: 0, y: 16 }}
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.2 }}
-      className="h-full"
     >
       {children}
     </motion.div>


### PR DESCRIPTION
## Summary
- remove the fixed h-full class from the page transition wrapper so pages size themselves to their content
- make the header fixed with a transparent top state and apply blur plus a soft gradient once scrolled
- give the hero section a full-bleed background image with overlay and adjust layout spacing so it sits directly beneath the header

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d12f67ad2c8328afc7c509b49eb4da