### PR TITLE
Adjust hero section padding

### DIFF
--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -28,8 +28,8 @@ export default function HeroSection() {
         <div className="absolute inset-0 bg-black/35" />
       </div>
 
-      <div className="w-full pt-12">
-        <div className="mx-auto flex w-full max-w-screen-lg flex-col items-center justify-start px-4 pt-8 pb-2 text-center sm:px-6 sm:pt-10 md:pt-14">
+      <div className="w-full">
+        <div className="mx-auto flex w-full max-w-screen-lg flex-col items-center justify-start px-4 pt-12 pb-2 text-center sm:px-6 sm:pt-14 md:pt-16">
           <div className="rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs font-jakarta text-white/90 backdrop-blur">
             +20.000 persone hanno già fatto il test
           </div>


### PR DESCRIPTION
## Summary
- move the hero section padding from the outer section to the inner content wrapper
- increase the base padding inside the hero content to keep the copy clear of the header

## Testing
- npm run lint
- npm run dev (visual verification of the home hero)


------
https://chatgpt.com/codex/tasks/task_e_68d137d11cd48328a8eeddab9109199d