### PR TITLE
Refine global background handling and motion ergonomics

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -20,10 +20,6 @@ html {
 body {
   color: var(--fg);
   background-color: var(--bg);
-  background-image:
-    radial-gradient(circle at center, rgba(255,45,45,0.08), rgba(5,5,6,0) 70%),
-    url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='200' height='200' viewBox='0 0 200 200'><filter id='g'><feTurbulence type='fractalNoise' baseFrequency='0.8' numOctaves='4'/></filter><rect width='100%' height='100%' filter='url(%23g)' opacity='0.15'/></svg>");
-  background-attachment: fixed;
   font-family: var(--font-roboto), sans-serif;
   overflow-x: hidden;
   max-width: 100%;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -62,6 +62,17 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             />
           </noscript>
         ) : null}
+        {/* BG globale fisso, non interfere con lo scroll del body */}
+        <div
+          aria-hidden
+          className="pointer-events-none fixed inset-0 -z-10"
+          style={{
+            background:
+              "radial-gradient(circle at center, rgba(255,45,45,0.08) 0%, rgba(5,5,6,0) 70%), url(\"data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='200' height='200' viewBox='0 0 200 200'><filter id='g'><feTurbulence type='fractalNoise' baseFrequency='0.8' numOctaves='4'/></filter><rect width='100%' height='100%' filter='url(%23g)' opacity='0.15'/></svg>\")",
+            backgroundRepeat: "repeat",
+            backgroundSize: "auto",
+          }}
+        />
         <Header />
         <main className="min-h-screen overflow-x-hidden">
           {children}

--- a/src/components/FAQSection.tsx
+++ b/src/components/FAQSection.tsx
@@ -37,7 +37,11 @@ export default function FAQSection() {
     transition: { duration: 0.6 },
   } as const;
   return (
-    <motion.section id="faq" className="py-10 sm:py-14" {...sectionProps}>
+    <motion.section
+      id="faq"
+      className="py-10 sm:py-14 scroll-mt-16 md:scroll-mt-20"
+      {...sectionProps}
+    >
       <Container>
         <h2 className="text-center font-heading font-extrabold tracking-[-0.5px] text-3xl">Domande frequenti</h2>
         <div className="mx-auto mt-8 max-w-3xl space-y-4">

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -9,9 +9,17 @@ export default function Header() {
   const [scrolled, setScrolled] = useState(false);
 
   useEffect(() => {
-    const onScroll = () => setScrolled(window.scrollY > 12);
+    let rAF = 0;
+    const onScroll = () => {
+      if (rAF) return;
+      rAF = requestAnimationFrame(() => {
+        const sc = window.scrollY > 12;
+        setScrolled((prev) => (prev === sc ? prev : sc));
+        rAF = 0;
+      });
+    };
     onScroll();
-    window.addEventListener("scroll", onScroll);
+    window.addEventListener("scroll", onScroll, { passive: true });
     return () => window.removeEventListener("scroll", onScroll);
   }, []);
 
@@ -45,7 +53,7 @@ export default function Header() {
             Affinity
           </Link>
         )}
-        <nav className="ml-auto flex items-center gap-3">
+        <nav className="ml-auto flex items-center gap-3" aria-label="Navigazione principale">
           <div className="hidden items-center gap-4 text-xs font-jakarta sm:flex sm:text-sm">
             <Link
               href="/#come-funziona"

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -11,11 +11,12 @@ const reduce =
 
 export default function HeroSection() {
   return (
-    <section className="relative flex min-h-[100vh] items-start overflow-hidden">
+    // isolate -> stacking context; z-0 per lo sfondo; contenuto a z-10
+    <section className="relative isolate flex min-h-[100vh] items-start overflow-hidden pt-12">
       {/* Background image */}
-      <div className="absolute inset-0 -z-10">
+      <div className="absolute inset-0 z-0">
         <Image
-          src="/hero.jpeg"
+          src="/hero.jpg"  // <-- usa il file reale in /public
           alt="Coppia che cammina insieme tenendosi per mano"
           fill
           priority
@@ -23,13 +24,17 @@ export default function HeroSection() {
         />
         {/* Overlay per contrasto del testo */}
         <div className="absolute inset-0 bg-black/35" />
+        <div
+          className="pointer-events-none absolute inset-x-0 bottom-0 h-28 sm:h-32 md:h-40 lg:h-48 bg-gradient-to-b from-transparent via-black/30 to-[var(--bg)]"
+        />
       </div>
 
-      <div className="w-full">
+      <div className="relative z-10 w-full">
         <div className="mx-auto flex w-full max-w-screen-lg flex-col items-center justify-start px-4 pt-12 pb-2 text-center sm:px-6 sm:pt-14 md:pt-16">
           <div className="rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs font-jakarta text-white/90 backdrop-blur">
             +20.000 persone hanno già fatto il test
           </div>
+
           <motion.h1
             initial={{ opacity: 0, y: 20 }}
             animate={{ opacity: 1, y: 0 }}
@@ -40,6 +45,7 @@ export default function HeroSection() {
             <br />
             relazioni non funzionano
           </motion.h1>
+
           <motion.p
             initial={{ opacity: 0, y: 20 }}
             animate={{ opacity: 1, y: 0 }}
@@ -48,6 +54,7 @@ export default function HeroSection() {
           >
             Un test gratuito in 5 minuti che ti apre gli occhi. E una guida basata su 500+ studi per cambiare davvero.
           </motion.p>
+
           <motion.div
             initial={{ opacity: 0, y: 20 }}
             animate={{ opacity: 1, y: 0 }}
@@ -61,6 +68,7 @@ export default function HeroSection() {
               Inizia il test gratuito
             </CTAButton>
           </motion.div>
+
           <motion.div
             initial={{ opacity: 0, y: 20 }}
             animate={{ opacity: 1, y: 0 }}
@@ -70,6 +78,7 @@ export default function HeroSection() {
             <span>⭐⭐⭐⭐⭐</span>
             <span>Valutazione media 4.8/5 da 20.000 utenti</span>
           </motion.div>
+
           <motion.div
             initial={{ opacity: 0, y: 20 }}
             animate={{ opacity: 1, y: 0 }}

--- a/src/components/HowItWorks.tsx
+++ b/src/components/HowItWorks.tsx
@@ -14,7 +14,11 @@ export default function HowItWorks() {
   const card =
     "relative rounded-2xl border border-[#333] bg-white/5 p-6 text-center backdrop-blur-sm shadow-lg shadow-black/20 transition-transform hover:-translate-y-1 hover:shadow-xl hover:shadow-black/30";
   return (
-    <motion.section id="come-funziona" className="py-10 sm:py-14" {...sectionProps}>
+    <motion.section
+      id="come-funziona"
+      className="py-10 sm:py-14 scroll-mt-16 md:scroll-mt-20"
+      {...sectionProps}
+    >
       <Container className="text-center">
         <h2 className="font-heading font-extrabold tracking-[-0.5px] text-3xl">Come funziona Affinity?</h2>
         <p className="mx-auto mt-4 max-w-2xl text-muted">

--- a/src/components/PageTransition.tsx
+++ b/src/components/PageTransition.tsx
@@ -1,14 +1,15 @@
 "use client";
 
-import { motion } from "framer-motion";
+import { motion, useReducedMotion } from "framer-motion";
 import { ReactNode } from "react";
 
 export default function PageTransition({ children }: { children: ReactNode }) {
+  const reduce = useReducedMotion();
   return (
     <motion.div
-      initial={{ opacity: 0, y: 16 }}
+      initial={{ opacity: 0, y: reduce ? 0 : 16 }}
       animate={{ opacity: 1, y: 0 }}
-      transition={{ duration: 0.2 }}
+      transition={{ duration: reduce ? 0 : 0.2, ease: "easeOut" }}
     >
       {children}
     </motion.div>

--- a/src/components/ProsConsSection.tsx
+++ b/src/components/ProsConsSection.tsx
@@ -14,7 +14,11 @@ export default function ProsConsSection() {
   const card =
     "relative overflow-hidden rounded-2xl border border-[#333] bg-white/5 p-8 md:p-6 text-center md:text-left backdrop-blur-sm transition-transform hover:-translate-y-1";
   return (
-    <motion.section id="perche-affinity" className="py-10 sm:py-14" {...sectionProps}>
+    <motion.section
+      id="perche-affinity"
+      className="py-10 sm:py-14 scroll-mt-16 md:scroll-mt-20"
+      {...sectionProps}
+    >
       <Container className="text-center">
         <h2 className="font-heading font-extrabold tracking-[-0.5px] text-3xl">Perché Affinity è diverso da tutto il resto</h2>
         <p className="mx-auto mt-4 max-w-2xl text-muted">

--- a/src/components/StickyCTABar.tsx
+++ b/src/components/StickyCTABar.tsx
@@ -4,8 +4,8 @@ import CTAButton from "@/components/CTAButton";
 
 export default function StickyCTABar() {
   return (
-    <div className="fixed inset-x-4 bottom-4 z-40 md:hidden sm:inset-x-6 sm:bottom-6">
-      <div className="mx-auto w-full max-w-screen-sm rounded-2xl bg-bg/80 px-4 py-3 shadow-lg shadow-black/30 backdrop-blur sm:max-w-screen-md">
+    <div className="fixed inset-x-4 bottom-4 z-40 md:hidden sm:inset-x-6 sm:bottom-6 pb-[env(safe-area-inset-bottom)]">
+      <div className="mx-auto w-full max-w-screen-sm rounded-2xl bg-bg/80 px-4 py-3 shadow-lg shadow-black/30 backdrop-blur supports-[backdrop-filter]:backdrop-blur sm:max-w-screen-md">
         <CTAButton
           href="/test"
           className="w-full max-w-full !flex justify-center !px-5 !py-3 text-base"


### PR DESCRIPTION
## Summary
- move the decorative radial/noise background from the body to a fixed, non-interactive layer rendered in the root layout to avoid extra scrollbars while keeping the look
- streamline header behavior with requestAnimationFrame scrolling, add safe-area padding to the sticky CTA, honor reduced-motion preferences in page transitions, and add scroll offsets for anchor sections
- remove the fixed background attachment from global styles now that the layout host manages the background layer

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d14e3b0388832889bea783d871767d