### PR TITLE
Remove vertical slide from page transition

### DIFF
--- a/src/components/PageTransition.tsx
+++ b/src/components/PageTransition.tsx
@@ -7,8 +7,8 @@ export default function PageTransition({ children }: { children: ReactNode }) {
   const reduce = useReducedMotion();
   return (
     <motion.div
-      initial={{ opacity: 0, y: reduce ? 0 : 16 }}
-      animate={{ opacity: 1, y: 0 }}
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
       transition={{ duration: reduce ? 0 : 0.2, ease: "easeOut" }}
     >
       {children}


### PR DESCRIPTION
## Summary
- stop applying vertical translation during page transitions while keeping the fade animation intact

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d15e9f9b9c83289d9a66a06d97c88d