### PR TITLE
Refine page transition layout for sticky CTA

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -29,9 +29,9 @@ export default function Home() {
           <FAQSection />
           <SectionSeparator />
           <FinalCTA />
-          <StickyCTABar />
         </div>
       </PageTransition>
+      <StickyCTABar />
     </div>
   );
 }

--- a/src/components/PageTransition.tsx
+++ b/src/components/PageTransition.tsx
@@ -1,17 +1,44 @@
 "use client";
 
 import { motion, useReducedMotion } from "framer-motion";
-import { ReactNode } from "react";
+import { isValidElement, useMemo } from "react";
+import type { ElementType, ReactElement, ReactNode } from "react";
 
-export default function PageTransition({ children }: { children: ReactNode }) {
+type PageTransitionProps = {
+  children: ReactNode;
+  asChild?: boolean;
+};
+
+export default function PageTransition({
+  children,
+  asChild = false,
+}: PageTransitionProps) {
   const reduce = useReducedMotion();
-  return (
-    <motion.div
-      initial={{ opacity: 0 }}
-      animate={{ opacity: 1 }}
-      transition={{ duration: reduce ? 0 : 0.2, ease: "easeOut" }}
-    >
-      {children}
-    </motion.div>
-  );
+  const motionProps = {
+    initial: { opacity: 0 },
+    animate: { opacity: 1 },
+    transition: { duration: reduce ? 0 : 0.2, ease: "easeOut" },
+  } as const;
+
+  const childElement = isValidElement(children)
+    ? (children as ReactElement)
+    : null;
+  const childType = childElement?.type as ElementType | undefined;
+
+  const MotionComponent = useMemo(() => {
+    if (!asChild || !childType) return null;
+    return motion.create(childType);
+  }, [asChild, childType]);
+
+  if (asChild && childElement && MotionComponent) {
+    return (
+      <MotionComponent
+        key={childElement.key ?? undefined}
+        {...childElement.props}
+        {...motionProps}
+      />
+    );
+  }
+
+  return <motion.div {...motionProps}>{children}</motion.div>;
 }


### PR DESCRIPTION
## Summary
- render the sticky CTA bar outside of the animated page transition wrapper so it can stay fixed on mobile
- add an asChild escape hatch to PageTransition for routes that need to animate an existing wrapper element

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d162ab2fec832894f156ee1dca1459