### PR TITLE
Fix sticky CTA scroll interactions

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -12,7 +12,6 @@
 }
 
 html {
-  scroll-behavior: smooth;
   overflow-x: hidden;
   max-width: 100%;
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -29,9 +29,9 @@ export default function Home() {
           <FAQSection />
           <SectionSeparator />
           <FinalCTA />
-          <StickyCTABar />
         </div>
       </PageTransition>
+      <StickyCTABar />
     </div>
   );
 }

--- a/src/components/CTAButton.tsx
+++ b/src/components/CTAButton.tsx
@@ -2,56 +2,133 @@
 
 import Link from "next/link";
 import { motion } from "framer-motion";
-import { ReactNode } from "react";
-
-type Props = {
-  href?: string;
-  children: ReactNode;
-  className?: string;
-  onClick?: () => void;
-  disabled?: boolean;
-  type?: "button" | "submit";
-};
+import {
+  type CSSProperties,
+  type ButtonHTMLAttributes,
+  ComponentPropsWithoutRef,
+  ReactNode,
+  useEffect,
+  useState,
+} from "react";
 
 const MotionLink = motion(Link);
 
-export default function CTAButton({
-  href,
-  children,
-  className = "",
-  onClick,
-  disabled = false,
-  type = "button",
-}: Props) {
-  const base = `inline-flex items-center justify-center rounded-2xl bg-gradient-to-r from-[#FF2D2D] to-[#FF7A7A] px-5 py-2 font-jakarta font-semibold text-fg shadow-[0_0_12px_rgba(255,45,45,0.45)] transition-all ${
-    disabled ? "cursor-not-allowed opacity-50" : "hover:to-red-dim hover:shadow-[0_0_20px_rgba(255,45,45,0.6)]"
+type BaseProps = {
+  className?: string;
+  children: ReactNode;
+  style?: CSSProperties;
+};
+
+type LinkCTAProps = {
+  href: string;
+} & Omit<ComponentPropsWithoutRef<typeof Link>, "href" | "className" | "children" | "style">;
+
+type ButtonCTAProps = Omit<
+  ButtonHTMLAttributes<HTMLButtonElement>,
+  "className" | "children" | "style"
+> & { href?: undefined };
+
+type CTAButtonProps = BaseProps & (LinkCTAProps | ButtonCTAProps);
+
+function useIsTouch() {
+  const [isTouch, setIsTouch] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    const mq = window.matchMedia("(hover: none), (pointer: coarse)");
+    const update = () => setIsTouch(mq.matches);
+    update();
+
+    if (typeof mq.addEventListener === "function") {
+      mq.addEventListener("change", update);
+      return () => mq.removeEventListener("change", update);
+    }
+
+    mq.addListener(update);
+    return () => mq.removeListener(update);
+  }, []);
+
+  return isTouch;
+}
+
+const motionInteraction = {
+  whileHover: { scale: 1.05 },
+  whileTap: { scale: 0.95 },
+  transition: { type: "spring" as const, stiffness: 500, damping: 15 },
+} as const;
+
+function baseClasses(disabled: boolean) {
+  return `inline-flex items-center justify-center rounded-2xl bg-gradient-to-r from-[#FF2D2D] to-[#FF7A7A] px-5 py-2 font-jakarta font-semibold text-fg shadow-[0_0_12px_rgba(255,45,45,0.45)] transition-all ${
+    disabled
+      ? "cursor-not-allowed opacity-50"
+      : "hover:to-red-dim hover:shadow-[0_0_20px_rgba(255,45,45,0.6)]"
   }`;
-  const motionProps = disabled
-    ? {}
-    : {
-        whileHover: { scale: 1.05 },
-        whileTap: { scale: 0.95 },
-        transition: { type: "spring" as const, stiffness: 500, damping: 15 },
-      };
-  if (href) {
+}
+
+export default function CTAButton(props: CTAButtonProps) {
+  const isTouch = useIsTouch();
+
+  if ("href" in props && props.href) {
+    const { href, className = "", children, style, ...rest } = props;
+    const restRecord = rest as Record<string, unknown>;
+    const hasDisableAttr = Object.prototype.hasOwnProperty.call(
+      restRecord,
+      "data-disable-motion-on-touch"
+    );
+    const disableAttrValue = hasDisableAttr
+      ? (restRecord["data-disable-motion-on-touch"] as string | undefined)
+      : undefined;
+    const disableAlways =
+      typeof disableAttrValue === "string" &&
+      disableAttrValue.toLowerCase() === "always";
+    const shouldDisableMotion =
+      disableAlways || (isTouch ?? hasDisableAttr) === true;
+    const motionProps = shouldDisableMotion ? undefined : motionInteraction;
+
     return (
       <MotionLink
         href={href}
-        className={`${base} ${className}`}
-        {...motionProps}
-        onClick={onClick}
+        className={`${baseClasses(false)} ${className}`}
+        style={{ touchAction: "manipulation", ...(style ?? {}) }}
+        {...(motionProps ?? {})}
+        {...rest}
       >
         {children}
       </MotionLink>
     );
   }
+
+  const {
+    className = "",
+    children,
+    style,
+    disabled = false,
+    type = "button",
+    ...rest
+  } = props;
+
+  const restRecord = rest as Record<string, unknown>;
+  const hasDisableAttr = Object.prototype.hasOwnProperty.call(
+    restRecord,
+    "data-disable-motion-on-touch"
+  );
+  const disableAttrValue = hasDisableAttr
+    ? (restRecord["data-disable-motion-on-touch"] as string | undefined)
+    : undefined;
+  const disableAlways =
+    typeof disableAttrValue === "string" &&
+    disableAttrValue.toLowerCase() === "always";
+  const shouldDisableMotion =
+    disabled || disableAlways || (isTouch ?? hasDisableAttr) === true;
+  const motionProps = shouldDisableMotion ? undefined : motionInteraction;
+
   return (
     <motion.button
-      className={`${base} ${className}`}
-      {...motionProps}
-      onClick={onClick}
+      className={`${baseClasses(disabled)} ${className}`}
+      style={{ touchAction: "manipulation", ...(style ?? {}) }}
       disabled={disabled}
       type={type}
+      {...(motionProps ?? {})}
+      {...rest}
     >
       {children}
     </motion.button>

--- a/src/components/PageTransition.tsx
+++ b/src/components/PageTransition.tsx
@@ -1,16 +1,47 @@
 "use client";
 
 import { motion, useReducedMotion } from "framer-motion";
-import { ReactNode } from "react";
+import { isValidElement, useMemo } from "react";
+import type { ElementType, ReactElement, ReactNode } from "react";
 
-export default function PageTransition({ children }: { children: ReactNode }) {
+type PageTransitionProps = {
+  children: ReactNode;
+  asChild?: boolean;
+};
+
+export default function PageTransition({
+  children,
+  asChild = false,
+}: PageTransitionProps) {
   const reduce = useReducedMotion();
+  const motionProps = {
+    initial: { opacity: 0 },
+    animate: { opacity: 1 },
+    transition: { duration: reduce ? 0 : 0.2, ease: "easeOut" },
+  } as const;
+
+  const childElement = isValidElement(children)
+    ? (children as ReactElement)
+    : null;
+  const childType = childElement?.type as ElementType | undefined;
+
+  const MotionComponent = useMemo(() => {
+    if (!asChild || !childType) return null;
+    return motion.create(childType);
+  }, [asChild, childType]);
+
+  if (asChild && childElement && MotionComponent) {
+    return (
+      <MotionComponent
+        key={childElement.key ?? undefined}
+        {...childElement.props}
+        {...motionProps}
+      />
+    );
+  }
+
   return (
-    <motion.div
-      initial={{ opacity: 0 }}
-      animate={{ opacity: 1 }}
-      transition={{ duration: reduce ? 0 : 0.2, ease: "easeOut" }}
-    >
+    <motion.div {...motionProps} style={{ willChange: "opacity" }}>
       {children}
     </motion.div>
   );

--- a/src/components/StickyCTABar.tsx
+++ b/src/components/StickyCTABar.tsx
@@ -1,18 +1,33 @@
 "use client";
 
+import { useEffect, useState } from "react";
+import { createPortal } from "react-dom";
 import CTAButton from "@/components/CTAButton";
 
 export default function StickyCTABar() {
-  return (
-    <div className="fixed inset-x-4 bottom-4 z-40 md:hidden sm:inset-x-6 sm:bottom-6 pb-[env(safe-area-inset-bottom)]">
-      <div className="mx-auto w-full max-w-screen-sm rounded-2xl bg-bg/80 px-4 py-3 shadow-lg shadow-black/30 backdrop-blur supports-[backdrop-filter]:backdrop-blur sm:max-w-screen-md">
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  if (!mounted) return null;
+
+  return createPortal(
+    <div
+      className="pointer-events-none fixed inset-x-4 bottom-4 z-50 md:hidden sm:inset-x-6 sm:bottom-6 pb-[env(safe-area-inset-bottom)]"
+      style={{ touchAction: "pan-y" }}
+    >
+      <div className="pointer-events-none mx-auto w-full max-w-screen-sm rounded-2xl bg-bg/80 px-4 py-3 shadow-lg shadow-black/30 backdrop-blur supports-[backdrop-filter]:backdrop-blur sm:max-w-screen-md">
         <CTAButton
           href="/test"
-          className="w-full max-w-full !flex justify-center !px-5 !py-3 text-base"
+          className="pointer-events-auto w-full max-w-full !flex select-none justify-center !px-5 !py-3 text-base"
+          data-disable-motion-on-touch
         >
           Inizia gratis
         </CTAButton>
       </div>
-    </div>
+    </div>,
+    document.body
   );
 }


### PR DESCRIPTION
## Summary
- remove the global smooth-scroll behavior so Safari keeps native gesture handling intact
- mount the sticky CTA bar in a body portal with touch-action and pointer-events tweaks, and disable motion states on touch inputs
- hint opacity compositing in PageTransition to keep the fade smooth while leaving fixed overlays outside the animation

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d162ab2fec832894f156ee1dca1459