### PR TITLE
Refine hero typography and CTA experience

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -9,10 +9,11 @@
   --border: #1F1F1F;
   --red: #FF2D2D;
   --red-dim: #FF7A7A;
+  --font-heading: var(--font-playfair, serif);
+  --font-body: var(--font-inter, sans-serif);
 }
 
 html {
-  scroll-behavior: smooth;
   overflow-x: hidden;
   max-width: 100%;
 }
@@ -20,15 +21,26 @@ html {
 body {
   color: var(--fg);
   background-color: var(--bg);
-  font-family: var(--font-roboto), sans-serif;
+  font-family: var(--font-body), system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
   overflow-x: hidden;
   max-width: 100%;
 }
 
 @layer base {
+  h1,
+  h2,
+  h3 {
+    font-family: var(--font-heading), serif;
+    letter-spacing: -0.01em;
+  }
   p {
     @apply leading-[1.7];
   }
+}
+
+/* subtle text shadow for hero heading readability */
+.text-shadow-soft {
+  text-shadow: 0 1px 16px rgba(0, 0, 0, 0.35);
 }
 
 *:focus-visible {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,12 @@
 import type { Metadata } from "next";
 import Script from "next/script";
-import { Poppins, Plus_Jakarta_Sans, Roboto } from "next/font/google";
+import {
+  Poppins,
+  Plus_Jakarta_Sans,
+  Roboto,
+  Playfair_Display,
+  Inter,
+} from "next/font/google";
 import "./globals.css";
 import Header from "@/components/Header";
 import SiteFooter from "@/components/SiteFooter";
@@ -20,6 +26,16 @@ const roboto = Roboto({
   weight: ["400", "500"],
   variable: "--font-roboto",
 });
+const playfair = Playfair_Display({
+  subsets: ["latin"],
+  weight: ["600", "700", "800"],
+  variable: "--font-playfair",
+});
+const inter = Inter({
+  subsets: ["latin"],
+  weight: ["400", "500", "600"],
+  variable: "--font-inter",
+});
 
 export const metadata: Metadata = {
   title: "Affinity",
@@ -36,7 +52,7 @@ export default function RootLayout({
   return (
     <html
       lang="it"
-      className={`${poppins.variable} ${jakarta.variable} ${roboto.variable}`}
+      className={`${poppins.variable} ${jakarta.variable} ${roboto.variable} ${playfair.variable} ${inter.variable}`}
     >
       <head>
         {gtmId ? (

--- a/src/components/CTAButton.tsx
+++ b/src/components/CTAButton.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { motion } from "framer-motion";
-import { ReactNode } from "react";
+import { CSSProperties, ReactNode } from "react";
 
 type Props = {
   href?: string;
@@ -11,9 +11,20 @@ type Props = {
   onClick?: () => void;
   disabled?: boolean;
   type?: "button" | "submit";
+  style?: CSSProperties;
 };
 
 const MotionLink = motion(Link);
+
+const isTouchDevice = () => {
+  if (typeof window === "undefined") return false;
+  if ("ontouchstart" in window) return true;
+  const hasCoarsePointer = window.matchMedia?.("(pointer: coarse)").matches;
+  const noHover = window.matchMedia?.("(hover: none)").matches;
+  const navigatorTouch =
+    typeof navigator !== "undefined" && navigator.maxTouchPoints > 0;
+  return Boolean(hasCoarsePointer || noHover || navigatorTouch);
+};
 
 export default function CTAButton({
   href,
@@ -22,17 +33,23 @@ export default function CTAButton({
   onClick,
   disabled = false,
   type = "button",
+  style,
 }: Props) {
   const base = `inline-flex items-center justify-center rounded-2xl bg-gradient-to-r from-[#FF2D2D] to-[#FF7A7A] px-5 py-2 font-jakarta font-semibold text-fg shadow-[0_0_12px_rgba(255,45,45,0.45)] transition-all ${
     disabled ? "cursor-not-allowed opacity-50" : "hover:to-red-dim hover:shadow-[0_0_20px_rgba(255,45,45,0.6)]"
   }`;
-  const motionProps = disabled
+  const touch = isTouchDevice();
+  const motionProps = disabled || touch
     ? {}
     : {
         whileHover: { scale: 1.05 },
         whileTap: { scale: 0.95 },
         transition: { type: "spring" as const, stiffness: 500, damping: 15 },
       };
+  const styleWithTouchAction: CSSProperties = {
+    touchAction: "manipulation",
+    ...style,
+  };
   if (href) {
     return (
       <MotionLink
@@ -40,6 +57,7 @@ export default function CTAButton({
         className={`${base} ${className}`}
         {...motionProps}
         onClick={onClick}
+        style={styleWithTouchAction}
       >
         {children}
       </MotionLink>
@@ -52,6 +70,7 @@ export default function CTAButton({
       onClick={onClick}
       disabled={disabled}
       type={type}
+      style={styleWithTouchAction}
     >
       {children}
     </motion.button>

--- a/src/components/FinalCTA.tsx
+++ b/src/components/FinalCTA.tsx
@@ -2,6 +2,7 @@
 
 import CTAButton from "@/components/CTAButton";
 import Container from "@/components/Container";
+import { CTA_COPY } from "@/lib/constants";
 import { motion } from "framer-motion";
 
 export default function FinalCTA() {
@@ -16,7 +17,7 @@ export default function FinalCTA() {
       <Container>
         <h2 className="font-heading font-extrabold tracking-[-0.5px] text-3xl">Pronto a iniziare?</h2>
         <CTAButton href="/test" className="mt-8 px-8 py-4">
-          Inizia il test gratuito
+          {CTA_COPY}
         </CTAButton>
       </Container>
     </motion.section>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { useEffect, useState } from "react";
 import { usePathname } from "next/navigation";
 import CTAButton from "./CTAButton";
+import { CTA_COPY } from "@/lib/constants";
 
 export default function Header() {
   const [scrolled, setScrolled] = useState(false);
@@ -65,12 +66,14 @@ export default function Header() {
               Privacy
             </Link>
           </div>
-          <CTAButton
-            href="/test"
-            className="ml-2 max-w-full !px-4 !py-2 text-xs sm:ml-4 sm:text-sm"
-          >
-            Inizia
-          </CTAButton>
+          <div className="ml-2 hidden sm:block sm:ml-4">
+            <CTAButton
+              href="/test"
+              className="max-w-full !px-4 !py-2 text-xs sm:text-sm"
+            >
+              {CTA_COPY}
+            </CTAButton>
+          </div>
         </nav>
       </div>
 

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -3,6 +3,8 @@
 import Image from "next/image";
 import CTAButton from "@/components/CTAButton";
 import HeroTicker from "@/components/HeroTicker";
+import { CTA_COPY } from "@/lib/constants";
+import { track } from "@/lib/track";
 import { motion } from "framer-motion";
 
 const reduce =
@@ -35,49 +37,55 @@ export default function HeroSection() {
             +20.000 persone hanno già fatto il test
           </div>
 
-          <motion.h1
-            initial={{ opacity: 0, y: 20 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={reduce ? { duration: 0 } : { duration: 0.6 }}
-            className="mt-4 mx-auto max-w-[16ch] font-heading text-[clamp(28px,6vw,48px)] font-extrabold leading-tight tracking-[-0.5px] text-balance break-words drop-shadow-[0_10px_25px_rgba(0,0,0,0.45)] sm:text-5xl md:text-6xl"
-          >
-            Scopri perché le tue
-            <br />
-            relazioni non funzionano
-          </motion.h1>
-
-          <motion.p
-            initial={{ opacity: 0, y: 20 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={reduce ? { duration: 0 } : { duration: 0.6, delay: 0.2 }}
-            className="mt-3 mx-auto max-w-[60ch] text-lg leading-relaxed text-white/80 text-pretty break-words hyphens-auto drop-shadow-[0_6px_16px_rgba(0,0,0,0.45)]"
-          >
-            Un test gratuito in 5 minuti che ti apre gli occhi. E una guida basata su 500+ studi per cambiare davvero.
-          </motion.p>
-
-          <motion.div
-            initial={{ opacity: 0, y: 20 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={reduce ? { duration: 0 } : { duration: 0.6, delay: 0.4 }}
-            className="mt-6 w-full drop-shadow-[0_12px_30px_rgba(0,0,0,0.35)] sm:mt-8 sm:w-auto"
-          >
-            <CTAButton
-              href="/test"
-              className="w-full max-w-full !flex justify-center !px-5 !py-3 text-base sm:w-auto sm:!px-6 sm:!py-3 sm:text-lg"
+          <div className="relative mt-8 w-full max-w-[28rem] mx-auto sm:mt-10 sm:max-w-[34rem]">
+            <div
+              aria-hidden
+              className="pointer-events-none absolute -inset-x-5 -top-6 bottom-0 rounded-[32px] bg-gradient-to-b from-black/75 via-black/40 to-transparent opacity-95 [mask-image:linear-gradient(180deg,rgba(0,0,0,0.85)_0%,rgba(0,0,0,0.45)_55%,rgba(0,0,0,0)_100%)]"
+            />
+            <motion.h1
+              initial={{ opacity: 0, y: 20 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={reduce ? { duration: 0 } : { duration: 0.6 }}
+              className="relative text-balance text-4xl font-semibold leading-tight text-white text-shadow-soft sm:text-5xl md:text-6xl"
             >
-              Inizia il test gratuito
-            </CTAButton>
-          </motion.div>
+              Scopri perché le tue
+              <br />
+              relazioni non funzionano
+            </motion.h1>
 
-          <motion.div
-            initial={{ opacity: 0, y: 20 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={reduce ? { duration: 0 } : { duration: 0.6, delay: 0.6 }}
-            className="mt-6 flex items-center justify-center gap-2 text-sm text-white/60"
-          >
-            <span>⭐⭐⭐⭐⭐</span>
-            <span>Valutazione media 4.8/5 da 20.000 utenti</span>
-          </motion.div>
+            <motion.p
+              initial={{ opacity: 0, y: 20 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={reduce ? { duration: 0 } : { duration: 0.6, delay: 0.2 }}
+              className="relative mt-3 text-base text-white/90 text-pretty sm:text-lg"
+            >
+              Un test gratuito in 5 minuti che ti apre gli occhi. E una guida basata su 500+ studi per cambiare davvero.
+            </motion.p>
+
+            <motion.div
+              initial={{ opacity: 0, y: 20 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={reduce ? { duration: 0 } : { duration: 0.6, delay: 0.4 }}
+              className="relative mt-4 w-full drop-shadow-[0_12px_30px_rgba(0,0,0,0.35)] sm:w-auto"
+            >
+              <CTAButton
+                href="/test"
+                className="w-full max-w-full !flex justify-center !px-5 !py-3 text-base sm:w-auto sm:!px-6 sm:!py-3 sm:text-lg"
+                onClick={() => track("cta_click_hero")}
+              >
+                {CTA_COPY}
+              </CTAButton>
+            </motion.div>
+
+            <motion.div
+              initial={{ opacity: 0, y: 20 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={reduce ? { duration: 0 } : { duration: 0.6, delay: 0.6 }}
+              className="relative mt-3 text-sm opacity-80"
+            >
+              ⭐️⭐️⭐️⭐️⭐️ 4,8/5 · 20.000+ valutazioni
+            </motion.div>
+          </div>
 
           <motion.div
             initial={{ opacity: 0, y: 20 }}

--- a/src/components/StickyCTABar.tsx
+++ b/src/components/StickyCTABar.tsx
@@ -1,18 +1,66 @@
 "use client";
 
+import { useEffect, useState } from "react";
+import { createPortal } from "react-dom";
 import CTAButton from "@/components/CTAButton";
+import { CTA_COPY } from "@/lib/constants";
+import { track } from "@/lib/track";
 
 export default function StickyCTABar() {
-  return (
-    <div className="fixed inset-x-4 bottom-4 z-40 md:hidden sm:inset-x-6 sm:bottom-6 pb-[env(safe-area-inset-bottom)]">
-      <div className="mx-auto w-full max-w-screen-sm rounded-2xl bg-bg/80 px-4 py-3 shadow-lg shadow-black/30 backdrop-blur supports-[backdrop-filter]:backdrop-blur sm:max-w-screen-md">
+  const [mounted, setMounted] = useState(false);
+  const [visible, setVisible] = useState(false);
+  const [tracked, setTracked] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  useEffect(() => {
+    let ticking = false;
+    const handleScroll = () => {
+      if (ticking) return;
+      ticking = true;
+      requestAnimationFrame(() => {
+        const doc = document.documentElement;
+        const max = doc.scrollHeight - window.innerHeight;
+        const progress = max > 0 ? window.scrollY / max : 0;
+        const shouldShow = progress >= 0.45;
+        setVisible(shouldShow);
+        if (shouldShow && !tracked) {
+          track("sticky_shown", { progress: 0.45 });
+          setTracked(true);
+        }
+        ticking = false;
+      });
+    };
+
+    window.addEventListener("scroll", handleScroll, { passive: true });
+    handleScroll();
+
+    return () => {
+      window.removeEventListener("scroll", handleScroll);
+    };
+  }, [tracked]);
+
+  if (!mounted || !visible) {
+    return null;
+  }
+
+  return createPortal(
+    <div
+      className="pointer-events-none fixed inset-x-4 bottom-4 z-50 md:hidden sm:inset-x-6 sm:bottom-6 pb-[calc(env(safe-area-inset-bottom)+12px)]"
+      style={{ touchAction: "pan-y" }}
+    >
+      <div className="pointer-events-none mx-auto w-full max-w-screen-sm rounded-2xl bg-bg/80 px-4 py-3 shadow-lg shadow-black/30 backdrop-blur supports-[backdrop-filter]:backdrop-blur sm:max-w-screen-md">
         <CTAButton
           href="/test"
-          className="w-full max-w-full !flex justify-center !px-5 !py-3 text-base"
+          className="pointer-events-auto w-full max-w-full !flex justify-center !px-5 !py-3 text-base"
+          onClick={() => track("cta_click_sticky")}
         >
-          Inizia gratis
+          {CTA_COPY}
         </CTAButton>
       </div>
-    </div>
+    </div>,
+    document.body,
   );
 }

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,0 +1,1 @@
+export const CTA_COPY = "Inizia il test gratuito";

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -19,10 +19,10 @@ const config: Config = {
         },
       },
       fontFamily: {
-        heading: ["var(--font-poppins)", "sans-serif"],
+        heading: ["var(--font-heading)", "serif"],
         jakarta: ["var(--font-jakarta)", "sans-serif"],
-        body: ["var(--font-roboto)", "sans-serif"],
-        sans: ["var(--font-roboto)", "sans-serif"],
+        body: ["var(--font-body)", "sans-serif"],
+        sans: ["var(--font-body)", "sans-serif"],
       },
       maxWidth: {
         container: "1200px",


### PR DESCRIPTION
## Summary
- import Playfair Display and Inter fonts via `next/font` and expose variables for heading/body usage
- refresh global typography styles and introduce a soft text shadow utility to improve hero readability
- restyle the hero with a localized gradient, unified CTA copy, social proof, and new tracking hooks
- gate the sticky CTA behind a 45% scroll threshold with safe-area padding and touch-safe motion handling
- centralize CTA copy and update CTAButton interactions for touch devices

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d1a1c23f4483288c5d7394ff6a1004