### PR TITLE
Set global background to solid black

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -82,12 +82,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         <div
           aria-hidden
           className="pointer-events-none fixed inset-0 -z-10"
-          style={{
-            background:
-              "radial-gradient(circle at center, rgba(255,45,45,0.08) 0%, rgba(5,5,6,0) 70%), url(\"data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='200' height='200' viewBox='0 0 200 200'><filter id='g'><feTurbulence type='fractalNoise' baseFrequency='0.8' numOctaves='4'/></filter><rect width='100%' height='100%' filter='url(%23g)' opacity='0.15'/></svg>\")",
-            backgroundRepeat: "repeat",
-            backgroundSize: "auto",
-          }}
+          style={{ backgroundColor: "#000000" }}
         />
         <Header />
         <main className="min-h-screen overflow-x-hidden">


### PR DESCRIPTION
## Summary
- replace the global fixed background gradient in the layout with a solid black fill to remove overlay textures

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d1ad6c53e483289ea7245110901ba1