### PR TITLE
feat: integrate ShaderGradient waterPlane background and unify landing cards

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@react-spring/three": "^9.7.4",
+    "@react-three/fiber": "^8.17.11",
+    "@shadergradient/react": "^2.3.6",
     "framer-motion": "^12.23.12",
     "lucide-react": "^0.542.0",
     "next": "14.2.10",
@@ -16,9 +19,11 @@
     "react-dom": "^18",
     "react-tsparticles": "^2.12.2",
     "recharts": "^3.1.2",
+    "three": "^0.167.0",
     "tsparticles": "^2.12.0"
   },
   "devDependencies": {
+    "@types/three": "^0.167.1",
     "@types/node": "^20",
     "@types/react": "^18",
     "@types/react-dom": "^18",

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -13,6 +13,11 @@
   --font-body: var(--font-inter, sans-serif);
 }
 
+html,
+body {
+  background: transparent !important;
+}
+
 html {
   overflow-x: hidden;
   max-width: 100%;
@@ -20,7 +25,6 @@ html {
 
 body {
   color: var(--fg);
-  background-color: var(--bg);
   font-family: var(--font-body), system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
   overflow-x: hidden;
   max-width: 100%;
@@ -35,6 +39,32 @@ body {
   }
   p {
     @apply leading-[1.7];
+  }
+}
+
+@layer components {
+  .aff-card {
+    @apply rounded-2xl border border-white/40 bg-black/30 backdrop-blur-sm shadow-[inset_0_1px_0_rgba(255,255,255,0.12)] p-6 md:p-8;
+  }
+
+  .aff-card h3,
+  .aff-card h4,
+  .aff-card h5 {
+    @apply text-white;
+  }
+
+  .aff-card p,
+  .aff-card .subtext,
+  .aff-card li {
+    @apply text-white/80;
+  }
+
+  .aff-card svg {
+    @apply text-white;
+  }
+
+  .aff-card :is([class*="text-red-"], [class*="fill-red-"], [class*="stroke-red-"]) {
+    @apply text-white;
   }
 }
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -8,6 +8,7 @@ import {
   Inter,
 } from "next/font/google";
 import "./globals.css";
+import dynamic from "next/dynamic";
 import Header from "@/components/Header";
 import SiteFooter from "@/components/SiteFooter";
 
@@ -37,9 +38,14 @@ const inter = Inter({
   variable: "--font-inter",
 });
 
+const BackgroundGradient = dynamic(
+  () => import("@/components/BackgroundGradient"),
+  { ssr: false },
+);
+
 export const metadata: Metadata = {
   title: "Affinity",
-  description: "Il test che rivela il tuo profilo nelle relazioni",
+  description: "ShaderGradient waterPlane background",
 };
 
 export default function RootLayout({
@@ -67,7 +73,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
           </Script>
         ) : null}
       </head>
-      <body className="bg-bg text-fg antialiased overflow-x-hidden">
+      <body className="text-fg antialiased overflow-x-hidden">
         {gtmId ? (
           <noscript>
             <iframe
@@ -78,16 +84,9 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             />
           </noscript>
         ) : null}
-        {/* BG globale fisso, non interfere con lo scroll del body */}
-        <div
-          aria-hidden
-          className="pointer-events-none fixed inset-0 -z-10"
-          style={{ backgroundColor: "#000000" }}
-        />
+        <BackgroundGradient />
         <Header />
-        <main className="min-h-screen overflow-x-hidden">
-          {children}
-        </main>
+        <main className="min-h-screen overflow-x-hidden">{children}</main>
         <SiteFooter />
       </body>
     </html>

--- a/src/components/AgainstGurus.tsx
+++ b/src/components/AgainstGurus.tsx
@@ -15,15 +15,15 @@ export default function AgainstGurus() {
   return (
     <motion.section className="py-10 sm:py-14" {...sectionProps}>
       <Container className="flex justify-center">
-        <div className="relative max-w-5xl overflow-hidden rounded-3xl border border-red/40 bg-white/5 p-8 sm:p-10 backdrop-blur-md">
-          <BadgeDollarSign className="mx-auto mb-6 h-8 w-8 text-white/80" />
-          <h2 className="text-center font-heading text-3xl font-bold leading-tight sm:text-4xl">
+        <div className="aff-card relative max-w-5xl text-center">
+          <BadgeDollarSign className="mx-auto mb-6 h-8 w-8 text-white" />
+          <h2 className="text-center font-heading text-3xl font-bold leading-tight text-white sm:text-4xl">
             Perché non è l’ennesimo corso da 1500€
           </h2>
-          <p className="mx-auto mt-4 max-w-3xl text-neutral-300 leading-relaxed">
+          <p className="mx-auto mt-4 max-w-3xl leading-relaxed text-white/80">
             I guru ti vendono promesse vaghe e corsi costosi pieni di fuffa.
-            Noi abbiamo condensato il meglio da <span className="text-red">500+ studi</span> di psicologia in un percorso chiaro e applicabile da subito.
-            Nessun filler — <span className="text-red">solo ciò che funziona davvero</span>.
+            Noi abbiamo condensato il meglio da <span className="font-semibold text-white">500+ studi</span> di psicologia in un percorso chiaro e applicabile da subito.
+            Nessun filler — <span className="font-semibold text-white">solo ciò che funziona davvero</span>.
           </p>
         </div>
       </Container>

--- a/src/components/BackgroundGradient.tsx
+++ b/src/components/BackgroundGradient.tsx
@@ -1,0 +1,22 @@
+// src/components/BackgroundGradient.tsx
+"use client";
+
+import { ShaderGradientCanvas, ShaderGradient } from "@shadergradient/react";
+import * as reactSpring from "@react-spring/three"; // peer richiesto
+
+void reactSpring;
+
+// Preset esatto (waterPlane) — decimali con il punto
+const URL =
+  "https://www.shadergradient.co/customize?animate=on&axesHelper=on&bgColor1=%23000000&bgColor2=%23000000&brightness=1.2&cAzimuthAngle=180&cDistance=2.4&cPolarAngle=95&cameraZoom=1&color1=%23ff6a1a&color2=%23ba0000&color3=%23fd172a&destination=onCanvas&embedMode=off&envPreset=city&format=gif&fov=45&frameRate=10&grain=off&lightType=3d&pixelDensity=1&positionX=0&positionY=-2.1&positionZ=0&range=enabled&rangeEnd=40&rangeStart=0&reflection=0.1&rotationX=0&rotationY=0&rotationZ=225&shader=defaults&type=waterPlane&uAmplitude=0&uDensity=1.8&uFrequency=5.5&uSpeed=0.2&uStrength=3&uTime=0.2&wireframe=false";
+
+export default function BackgroundGradient() {
+  return (
+    <div className="fixed inset-0 -z-10 pointer-events-none" style={{ width: "100%", height: "100%" }}>
+      <ShaderGradientCanvas style={{ width: "100%", height: "100%" }} dpr={[1, 1.5]}>
+        {/* Controllo via URL per look identico */}
+        <ShaderGradient control="query" urlString={URL} />
+      </ShaderGradientCanvas>
+    </div>
+  );
+}

--- a/src/components/FAQSection.tsx
+++ b/src/components/FAQSection.tsx
@@ -48,20 +48,17 @@ export default function FAQSection() {
           {faqs.map((f, i) => {
             const isOpen = open === i;
             return (
-              <div
-                key={f.q}
-                className="rounded-2xl border border-[#333] bg-white/5 p-4 backdrop-blur-sm shadow-lg shadow-black/20"
-              >
+              <div key={f.q} className="aff-card space-y-2">
                 <button
-                  className="flex w-full items-center justify-between text-left font-jakarta"
+                  className="flex w-full items-center justify-between text-left font-jakarta text-white"
                   onClick={() => setOpen(isOpen ? null : i)}
                 >
                   <span className="flex items-center gap-2">
-                    <HelpCircle className="h-5 w-5 opacity-80 animate-icon-bounce" />
+                    <HelpCircle className="h-5 w-5 text-white animate-icon-bounce" />
                     {f.q}
                   </span>
                   <motion.span animate={{ rotate: isOpen ? 180 : 0 }}>
-                    <ChevronDown className="h-4 w-4" />
+                    <ChevronDown className="h-4 w-4 text-white" />
                   </motion.span>
                 </button>
                 <motion.div
@@ -69,7 +66,7 @@ export default function FAQSection() {
                   animate={{ height: isOpen ? "auto" : 0, opacity: isOpen ? 1 : 0 }}
                   className="overflow-hidden"
                 >
-                  <p className="mt-2 text-sm text-muted">{f.a}</p>
+                  <p className="mt-2 text-sm text-white/80">{f.a}</p>
                 </motion.div>
               </div>
             );

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -13,13 +13,6 @@ export default function HeroSection() {
   return (
     // isolate -> stacking context; z-0 per lo sfondo; contenuto a z-10
     <section className="relative isolate flex min-h-[100vh] items-start overflow-hidden pt-12">
-      {/* Background */}
-      <div className="absolute inset-0 z-0 bg-black">
-        <div className="absolute inset-0 bg-black/35" />
-        <div
-          className="pointer-events-none absolute inset-x-0 bottom-0 h-28 sm:h-32 md:h-40 lg:h-48 bg-gradient-to-b from-transparent via-black/30 to-[var(--bg)]"
-        />
-      </div>
 
       <div className="relative z-10 w-full">
         <div className="mx-auto flex w-full max-w-screen-lg flex-col items-center justify-start px-4 pt-12 pb-2 text-center sm:px-6 sm:pt-14 md:pt-16">

--- a/src/components/HowItWorks.tsx
+++ b/src/components/HowItWorks.tsx
@@ -12,7 +12,7 @@ export default function HowItWorks() {
     transition: { duration: 0.6 },
   } as const;
   const card =
-    "relative rounded-2xl border border-[#333] bg-white/5 p-6 text-center backdrop-blur-sm shadow-lg shadow-black/20 transition-transform hover:-translate-y-1 hover:shadow-xl hover:shadow-black/30";
+    "aff-card relative text-center transition-transform hover:-translate-y-1 md:text-left";
   return (
     <motion.section
       id="come-funziona"
@@ -32,17 +32,17 @@ export default function HowItWorks() {
               className={card}
               {...{ transition: { delay: 0.1 } }}
             >
-              <FileText className="mx-auto h-8 w-8 text-red animate-icon-bounce" />
-              <h3 className="mt-4 font-jakarta text-lg">Rispondi al test</h3>
-              <p className="mt-2 text-sm text-muted">30 domande, meno di 5 minuti.</p>
+              <FileText className="mx-auto h-8 w-8 text-white animate-icon-bounce" />
+              <h3 className="mt-4 font-jakarta text-lg font-semibold text-white">Rispondi al test</h3>
+              <p className="mt-2 text-sm text-white/80">30 domande, meno di 5 minuti.</p>
             </motion.div>
             <motion.div
               className={card}
               {...{ transition: { delay: 0.2 } }}
             >
-              <BarChart2 className="mx-auto h-8 w-8 text-red animate-icon-bounce" />
-              <h3 className="mt-4 font-jakarta text-lg">Scopri il tuo profilo</h3>
-              <p className="mt-2 text-sm text-muted">
+              <BarChart2 className="mx-auto h-8 w-8 text-white animate-icon-bounce" />
+              <h3 className="mt-4 font-jakarta text-lg font-semibold text-white">Scopri il tuo profilo</h3>
+              <p className="mt-2 text-sm text-white/80">
                 Punti di forza, errori invisibili e schemi che ti sabotano.
               </p>
             </motion.div>
@@ -50,9 +50,9 @@ export default function HowItWorks() {
               className={card}
               {...{ transition: { delay: 0.3 } }}
             >
-              <Key className="mx-auto h-8 w-8 text-red animate-icon-bounce" />
-              <h3 className="mt-4 font-jakarta text-lg">Sblocca la Guida Premium</h3>
-              <p className="mt-2 text-sm text-muted">Oltre 500 libri, studi e meta-analisi condensati in strategie pratiche e applicabili.</p>
+              <Key className="mx-auto h-8 w-8 text-white animate-icon-bounce" />
+              <h3 className="mt-4 font-jakarta text-lg font-semibold text-white">Sblocca la Guida Premium</h3>
+              <p className="mt-2 text-sm text-white/80">Oltre 500 libri, studi e meta-analisi condensati in strategie pratiche e applicabili.</p>
             </motion.div>
           </div>
         </div>

--- a/src/components/Manifesto.tsx
+++ b/src/components/Manifesto.tsx
@@ -15,23 +15,23 @@ export default function Manifesto() {
   return (
     <motion.section className="py-10 sm:py-14" {...sectionProps}>
       <Container className="flex justify-center">
-        <div className="relative max-w-5xl overflow-hidden rounded-3xl border border-red/40 bg-white/5 p-8 sm:p-10 text-center backdrop-blur-md">
-          <Heart className="mx-auto mb-6 h-8 w-8 text-white/80" />
-          <h2 className="relative mx-auto inline-block font-heading text-3xl font-bold tracking-[-0.5px] leading-tight sm:text-4xl">
+        <div className="aff-card relative max-w-5xl text-center">
+          <Heart className="mx-auto mb-6 h-8 w-8 text-white" />
+          <h2 className="relative mx-auto inline-block font-heading text-3xl font-bold tracking-[-0.5px] leading-tight text-white sm:text-4xl">
             Perché abbiamo creato Affinity
             <motion.span
-              className="absolute bottom-0 left-1/2 h-[2px] w-0 -translate-x-1/2 bg-red"
+              className="absolute bottom-0 left-1/2 h-[2px] w-0 -translate-x-1/2 bg-white"
               initial={{ width: 0 }}
               whileInView={{ width: "100%" }}
               viewport={{ once: true }}
               transition={{ duration: 0.6 }}
             />
           </h2>
-          <p className="mx-auto mt-4 max-w-3xl text-neutral-300 leading-relaxed">
+          <p className="mx-auto mt-4 max-w-3xl leading-relaxed text-white/80">
             L’amore oggi è fatto di swipe. Superficiale, fugace.
             Noi ci siamo persi lì: relazioni che ripetono sempre lo stesso film.
-            Affinity nasce per farti ricentrare, far crescere <span className="text-red">legami veri</span>.
-            È la <span className="text-red">mappa</span> che avremmo voluto avere. Ora è qui, per te.
+            Affinity nasce per farti ricentrare, far crescere <span className="font-semibold text-white">legami veri</span>.
+            È la <span className="font-semibold text-white">mappa</span> che avremmo voluto avere. Ora è qui, per te.
           </p>
         </div>
       </Container>

--- a/src/components/MiniBenefits.tsx
+++ b/src/components/MiniBenefits.tsx
@@ -44,7 +44,7 @@ export default function MiniBenefits() {
   } as const;
 
 const baseCard =
-  "flex flex-col gap-4 rounded-2xl border-2 border-red/50 bg-black/20 p-6 transition hover:shadow-[0_0_20px_rgba(229,9,20,0.35)]";
+  "aff-card flex flex-col gap-4 transition-transform duration-300 hover:-translate-y-1";
 
   return (
     <section className="pt-0 pb-12 sm:pt-2 sm:pb-14 lg:pt-4">
@@ -64,10 +64,10 @@ const baseCard =
                 i === 2 ? "md:col-span-2 md:max-w-2xl md:mx-auto" : ""
               }`}
             >
-              <Icon className="h-10 w-10 text-white/80" />
+              <Icon className="h-10 w-10 text-white" />
               <div>
                 <h3 className="font-jakarta text-xl font-semibold text-white">{title}</h3>
-                <p className="mt-1 text-sm leading-relaxed text-[#B3B3B3]">{desc}</p>
+                <p className="mt-1 text-sm leading-relaxed text-white/80">{desc}</p>
               </div>
             </motion.div>
           ))}

--- a/src/components/ProsConsSection.tsx
+++ b/src/components/ProsConsSection.tsx
@@ -12,7 +12,7 @@ export default function ProsConsSection() {
     transition: { duration: 0.6 },
   } as const;
   const card =
-    "relative overflow-hidden rounded-2xl border border-[#333] bg-white/5 p-8 md:p-6 text-center md:text-left backdrop-blur-sm transition-transform hover:-translate-y-1";
+    "aff-card relative overflow-hidden text-center transition-transform hover:-translate-y-1 md:text-left";
   return (
     <motion.section
       id="perche-affinity"
@@ -26,18 +26,15 @@ export default function ProsConsSection() {
         </p>
         <div className="mt-12 grid gap-8 md:grid-cols-2 md:gap-6">
           <motion.div
-            className={
-              card +
-              " hover:shadow-[0_0_24px_rgba(229,9,20,0.35)] before:absolute before:inset-0 before:-z-10 before:rounded-2xl before:bg-red-500/10 before:blur-xl"
-            }
+            className={card}
             {...{ transition: { delay: 0.1 } }}
           >
             <div className="relative mx-auto mb-6 flex h-16 w-16 items-center justify-center rounded-full bg-white/10 md:mx-0">
-              <span className="absolute inset-0 -z-10 rounded-full bg-red/20 blur-lg" />
-              <X className="h-10 w-10 text-red animate-icon-bounce" />
+              <span className="absolute inset-0 -z-10 rounded-full bg-white/20 blur-lg" />
+              <X className="h-10 w-10 text-white animate-icon-bounce" />
             </div>
-            <h3 className="font-jakarta font-semibold">Problemi</h3>
-            <ul className="mt-4 space-y-2 text-sm text-muted text-left">
+            <h3 className="font-jakarta font-semibold text-white">Problemi</h3>
+            <ul className="mt-4 space-y-2 text-sm text-white/80 text-left">
               <li>Attiri sempre le persone sbagliate e finisce nello stesso modo.</li>
               <li>Dopo poco perdono interesse e non capisci perché.</li>
               <li>Su Google e TikTok trovi solo consigli banali e contraddittori.</li>
@@ -46,18 +43,15 @@ export default function ProsConsSection() {
             </ul>
           </motion.div>
           <motion.div
-            className={
-              card +
-              " hover:shadow-[0_0_24px_rgba(34,197,94,0.35)] before:absolute before:inset-0 before:-z-10 before:rounded-2xl before:bg-green-500/10 before:blur-xl"
-            }
+            className={card}
             {...{ transition: { delay: 0.2 } }}
           >
             <div className="relative mx-auto mb-6 flex h-16 w-16 items-center justify-center rounded-full bg-white/10 md:mx-0">
-              <span className="absolute inset-0 -z-10 rounded-full bg-green-500/20 blur-lg" />
-              <Check className="h-10 w-10 text-green-500 animate-icon-bounce" />
+              <span className="absolute inset-0 -z-10 rounded-full bg-white/20 blur-lg" />
+              <Check className="h-10 w-10 text-white animate-icon-bounce" />
             </div>
-            <h3 className="font-jakarta font-semibold">Soluzioni</h3>
-            <ul className="mt-4 space-y-2 text-sm text-muted text-left">
+            <h3 className="font-jakarta font-semibold text-white">Soluzioni</h3>
+            <ul className="mt-4 space-y-2 text-sm text-white/80 text-left">
               <li>Scopri subito perché ti accade sempre lo stesso schema.</li>
               <li>Capisci i tuoi errori nascosti e come smettere di ripeterli.</li>
               <li>Accedi alla Guida Premium: 500+ libri e studi tradotti in strategie chiare.</li>

--- a/src/components/SiteFooter.tsx
+++ b/src/components/SiteFooter.tsx
@@ -2,7 +2,7 @@ import Link from "next/link";
 
 export default function SiteFooter() {
   return (
-    <footer className="relative bg-bg text-xs text-gray-400">
+    <footer className="relative text-xs text-gray-400">
       <div className="pointer-events-none absolute inset-x-0 top-0 h-px bg-white/10" />
       <div className="pointer-events-none absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-red/40 to-transparent blur-sm" />
       <div className="mx-auto max-w-container px-4 py-6 md:grid md:grid-cols-3 md:items-center md:gap-4">


### PR DESCRIPTION
## Summary
- add a dedicated ShaderGradient background component preconfigured with the waterPlane preset
- mount the gradient once in the root layout with a client-only dynamic import, update metadata, and make global backgrounds transparent
- relax legacy overlays so the shader remains visible, keeping only the hero content backing box, and add the required three.js packages
- remove the remaining hero-level overlays that still darkened the canvas so the preset stays unobstructed
- unify all landing page cards with a reusable aff-card style so every box uses the same dark glassmorphism treatment with white text and icons

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d1b026c06883288ecfa845aa0ef547