### PR TITLE
Reduce spacing below badges section

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -14,22 +14,24 @@ export default function Home() {
   return (
     <div className="relative isolate">
       <PageTransition>
-        <div className="relative z-10">
+        <main className="relative z-10 space-y-12 md:space-y-16">
           <HeroSection />
           <MiniBenefits />
-          <SectionSeparator />
-          <HowItWorks />
-          <SectionSeparator />
-          <ProsConsSection />
-          <SectionSeparator />
-          <AgainstGurus />
-          <SectionSeparator />
-          <Manifesto />
-          <SectionSeparator />
-          <FAQSection />
-          <SectionSeparator />
-          <FinalCTA />
-        </div>
+          <section id="after-badges" className="mt-2 md:mt-4">
+            <SectionSeparator className="my-3 sm:my-5" />
+            <HowItWorks />
+            <SectionSeparator />
+            <ProsConsSection />
+            <SectionSeparator />
+            <AgainstGurus />
+            <SectionSeparator />
+            <Manifesto />
+            <SectionSeparator />
+            <FAQSection />
+            <SectionSeparator />
+            <FinalCTA />
+          </section>
+        </main>
       </PageTransition>
       <StickyCTABar />
     </div>

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -12,10 +12,12 @@ const reduce =
 export default function HeroSection() {
   return (
     // isolate -> stacking context; z-0 per lo sfondo; contenuto a z-10
-    <section className="relative isolate flex min-h-[100vh] items-start overflow-hidden pt-12">
-
+    <section
+      id="hero"
+      className="relative isolate flex min-h-[100vh] items-start overflow-hidden pt-10 pb-12 sm:pt-12 md:pb-16 lg:min-h-[calc(100vh-14rem)]"
+    >
       <div className="relative z-10 w-full">
-        <div className="mx-auto flex w-full max-w-screen-lg flex-col items-center justify-start px-4 pt-12 pb-2 text-center sm:px-6 sm:pt-14 md:pt-16">
+        <div className="mx-auto flex w-full max-w-screen-lg flex-col items-center justify-start px-4 pt-8 pb-0 text-center sm:px-6 sm:pt-12 md:pt-14">
           <div className="rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs font-jakarta text-white/90 backdrop-blur">
             +20.000 persone hanno già fatto il test
           </div>
@@ -74,7 +76,7 @@ export default function HeroSection() {
             initial={{ opacity: 0, y: 20 }}
             animate={{ opacity: 1, y: 0 }}
             transition={reduce ? { duration: 0 } : { duration: 0.6, delay: 0.6 }}
-            className="w-full mt-6 sm:mt-6 lg:mt-8 lg:mb-6"
+            className="w-full mt-6 sm:mt-6 lg:mt-8"
           >
             <HeroTicker />
           </motion.div>

--- a/src/components/MiniBenefits.tsx
+++ b/src/components/MiniBenefits.tsx
@@ -47,7 +47,7 @@ const baseCard =
   "aff-card flex flex-col gap-4 transition-transform duration-300 hover:-translate-y-1";
 
   return (
-    <section className="pt-0 pb-12 sm:pt-2 sm:pb-14 lg:pt-4">
+    <section id="badges" className="pt-0 pb-6 sm:pt-1 sm:pb-8 lg:pt-2 lg:pb-10">
       <Container>
         <motion.div
           variants={container}


### PR DESCRIPTION
## Summary
- trim the hero section height and padding to raise the content that follows
- tighten the badges row spacing with updated padding and identifiers for anchors
- reorganize the home page layout with a spaced main wrapper and a light after-badges offset

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d1be1c65ac8328b13220ac0e1da1d3