### PR TITLE
Prevent horizontal overflow on html and body

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -17,11 +17,15 @@
 html,
 body {
   background: transparent !important;
+  /* SOLUZIONE: Nascondi overflow orizzontale */
+  overflow-x: hidden !important;
+  max-width: 100vw;
 }
 
 html {
-  max-width: 100%;
   scroll-behavior: smooth;
+  /* Previeni scroll orizzontale a livello globale */
+  overscroll-behavior-x: none;
 }
 
 @media (prefers-reduced-motion: reduce) {
@@ -33,7 +37,9 @@ html {
 body {
   color: var(--fg);
   font-family: var(--font-body), system-ui, -apple-system, "Segoe UI", sans-serif;
-  max-width: 100%;
+  /* Assicurati che il body non causi overflow */
+  width: 100%;
+  position: relative;
 }
 
 @layer base {


### PR DESCRIPTION
## Summary
- hide horizontal overflow and limit viewport width on html/body to stop horizontal scrolling
- add defensive overscroll behavior on html and ensure body sizing avoids overflow

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d5174dac108328988ad46a05811d72