### PR TITLE
Adjust layout overflow to fix double scroll

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -20,7 +20,9 @@ body {
 }
 
 html {
+  height: 100%;
   max-width: 100%;
+  overflow-y: auto;
   scroll-behavior: smooth;
 }
 
@@ -31,9 +33,13 @@ html {
 }
 
 body {
+  height: 100%;
+  margin: 0;
+  padding: 0;
   color: var(--fg);
   font-family: var(--font-body), system-ui, -apple-system, "Segoe UI", sans-serif;
   max-width: 100%;
+  overscroll-behavior: none;
 }
 
 @layer base {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -40,7 +40,10 @@ export default function RootLayout({
   const gtmId = process.env.NEXT_PUBLIC_GTM_ID;
 
   return (
-    <html lang="it" className={`${inter.variable} ${manrope.variable} ${poppins.variable}`}>
+    <html
+      lang="it"
+      className={`h-full ${inter.variable} ${manrope.variable} ${poppins.variable}`}
+    >
       <head>
         {gtmId ? (
           <Script id="gtm-base" strategy="afterInteractive">
@@ -54,7 +57,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
           </Script>
         ) : null}
       </head>
-      <body className="text-fg antialiased">
+      <body className="flex min-h-full flex-col overflow-x-hidden text-fg antialiased">
         {gtmId ? (
           <noscript>
             <iframe
@@ -67,9 +70,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         ) : null}
         <BackgroundGradient />
         <Header />
-        <main className="min-h-screen">
-          <div className="overflow-x-hidden">{children}</div>
-        </main>
+        <main className="flex-1 overflow-x-hidden">{children}</main>
         <SiteFooter />
       </body>
     </html>

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -11,7 +11,7 @@ const reduce =
 export default function HeroSection() {
   return (
     // isolate -> stacking context; z-0 per lo sfondo; contenuto a z-10
-    <section className="relative isolate flex min-h-[100vh] items-start overflow-hidden pt-12">
+    <section className="relative isolate flex min-h-screen min-h-[100svh] items-start overflow-hidden pt-12">
 
       <div className="relative z-10 w-full">
         <div className="mx-auto flex w-full max-w-screen-xl flex-col items-start gap-12 px-4 pt-12 pb-2 sm:px-6 sm:pt-14 md:pt-16 lg:flex-row lg:items-center lg:gap-16">


### PR DESCRIPTION
## Summary
- give the html element full height and move the single scroll context to the document instead of nested wrappers
- update the root layout to use a flex column body, removing the extra min-h-screen wrapper that was forcing a second scroll container
- switch the hero section to 100svh to prevent mobile viewport jumps while keeping a desktop fallback

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d51bb7a10c8328bfaae0ead4f676e2