### PR TITLE
Fix iOS Safari white flash artifacts

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -16,7 +16,8 @@
 
 html,
 body {
-  background: transparent !important;
+  /* Solid background to avoid Safari compositing flashes under fixed/backdrop layers */
+  background: var(--bg) !important;
 }
 
 html {

--- a/src/components/BackgroundGradient.tsx
+++ b/src/components/BackgroundGradient.tsx
@@ -54,7 +54,6 @@ export default function BackgroundGradient() {
         width: "100%",
         height: "100%",
         willChange: "transform, opacity",
-        contain: "layout paint size",
       }}
     >
       <ShaderGradientCanvas

--- a/src/components/StickyCTABar.tsx
+++ b/src/components/StickyCTABar.tsx
@@ -7,6 +7,10 @@ import { CTA_COPY } from "@/lib/constants";
 import { track } from "@/lib/track";
 import { useScrollProgress } from "@/lib/useScrollProgress";
 
+const isIOS =
+  typeof navigator !== "undefined" &&
+  /iPad|iPhone|iPod/.test(navigator.userAgent);
+
 export default function StickyCTABar() {
   const [mounted, setMounted] = useState(false);
   const [tracked, setTracked] = useState(false);
@@ -26,7 +30,7 @@ export default function StickyCTABar() {
 
   const ctaContent = useMemo(
     () => (
-      <div className="pointer-events-none mx-auto w-full max-w-screen-sm rounded-2xl bg-bg/80 px-4 py-3 shadow-lg shadow-black/30 backdrop-blur supports-[backdrop-filter]:backdrop-blur sm:max-w-screen-md">
+      <div className="pointer-events-none mx-auto w-full max-w-screen-sm rounded-2xl bg-bg/80 px-4 py-3 shadow-lg shadow-black/30 sm:max-w-screen-md">
         <CTAButton
           href="/test"
           className="pointer-events-auto w-full max-w-full !flex justify-center !px-5 !py-3 text-base"
@@ -47,7 +51,7 @@ export default function StickyCTABar() {
     <div
       className={`pointer-events-none fixed inset-x-4 bottom-4 z-50 transition-transform transition-opacity duration-300 ease-out md:hidden sm:inset-x-6 sm:bottom-6 pb-[calc(env(safe-area-inset-bottom)+12px)] ${
         visible ? "translate-y-0 opacity-100" : "translate-y-full opacity-0"
-      }`}
+      } ${isIOS ? "" : "supports-[backdrop-filter]:backdrop-blur"}`}
       style={{ touchAction: "pan-y" }}
     >
       {ctaContent}


### PR DESCRIPTION
## Summary
- set the document background to the theme color to avoid transparent flashes in iOS Safari
- relax fixed gradient compositing hints to prevent viewport resize artifacts
- disable sticky CTA backdrop blur on iOS devices while keeping it for other platforms

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d52c3a77c483289821e27df04db0a1