### PR TITLE
Improve hero responsiveness on large desktops

### DIFF
--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -11,10 +11,10 @@ const reduce =
 export default function HeroSection() {
   return (
     // isolate -> stacking context; z-0 per lo sfondo; contenuto a z-10
-    <section className="relative isolate flex min-h-screen min-h-[100svh] items-start overflow-hidden pt-12">
+    <section className="relative isolate flex w-[min(100dvw,100%)] min-h-screen min-h-[100svh] items-start overflow-hidden">
 
       <div className="relative z-10 w-full">
-        <div className="mx-auto flex w-full max-w-screen-xl flex-col items-start gap-12 px-4 pt-12 pb-2 sm:px-6 sm:pt-14 md:pt-16 lg:flex-row lg:items-center lg:gap-16">
+        <div className="mx-auto flex w-full max-w-[min(90rem,90vw)] flex-col items-start gap-12 px-4 pt-[clamp(3rem,8vh,5.5rem)] pb-2 sm:px-6 lg:flex-row lg:items-center lg:gap-16">
           <div className="flex w-full max-w-[32rem] flex-col items-start text-left sm:max-w-[36rem]">
             <div className="rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs font-body text-white/90 backdrop-blur">
               +20.000 persone hanno già fatto il test
@@ -71,7 +71,7 @@ export default function HeroSection() {
           initial={{ opacity: 0, y: 20 }}
           animate={{ opacity: 1, y: 0 }}
           transition={reduce ? { duration: 0 } : { duration: 0.6, delay: 0.6 }}
-          className="mt-12 w-full sm:mt-14 lg:mt-14 xl:mt-16 lg:mb-6"
+          className="mt-[clamp(3rem,8vh,5rem)] w-full lg:mb-[clamp(1.5rem,4vh,3rem)]"
         >
           <HeroTicker />
         </motion.div>

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -11,21 +11,21 @@ const reduce =
 export default function HeroSection() {
   return (
     // isolate -> stacking context; z-0 per lo sfondo; contenuto a z-10
-    <section className="relative isolate flex w-[min(100dvw,100%)] min-h-screen min-h-[100svh] items-start overflow-hidden">
+    <section className="relative isolate flex w-[min(100dvw,100%)] min-h-[min(100svh,70rem)] items-start overflow-hidden 2xl:min-h-[min(100svh,64rem)]">
 
       <div className="relative z-10 w-full">
-        <div className="mx-auto flex w-full max-w-[min(90rem,90vw)] flex-col items-start gap-12 px-4 pt-[clamp(3rem,8vh,5.5rem)] pb-2 sm:px-6 lg:flex-row lg:items-center lg:gap-16">
+        <div className="mx-auto flex w-full max-w-[min(96rem,92vw)] flex-col items-start gap-12 px-4 pt-[clamp(3rem,8vh,5.5rem)] pb-2 sm:px-6 lg:flex-row lg:items-center lg:gap-16 xl:gap-20">
           <div className="flex w-full max-w-[32rem] flex-col items-start text-left sm:max-w-[36rem]">
             <div className="rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs font-body text-white/90 backdrop-blur">
               +20.000 persone hanno già fatto il test
             </div>
 
-            <div className="mt-6 flex w-fit max-w-[32rem] flex-col items-start sm:max-w-[36rem]">
+            <div className="mt-6 flex w-fit max-w-[32rem] flex-col items-start sm:max-w-[36rem] xl:max-w-[42rem]">
               <motion.h1
                 initial={{ opacity: 0, y: 20 }}
                 animate={{ opacity: 1, y: 0 }}
                 transition={reduce ? { duration: 0 } : { duration: 0.6 }}
-                className="w-full text-left text-4xl font-bold leading-tight tracking-tight text-white text-shadow-soft sm:text-5xl md:text-6xl"
+                className="w-full text-left text-4xl font-bold leading-tight tracking-tight text-white text-shadow-soft sm:text-5xl md:text-6xl xl:text-7xl 2xl:text-8xl"
               >
                 <span className="block w-full whitespace-nowrap">Scopri perché le tue</span>
                 <span className="block w-full whitespace-nowrap">relazioni non</span>
@@ -36,7 +36,7 @@ export default function HeroSection() {
                 initial={{ opacity: 0, y: 20 }}
                 animate={{ opacity: 1, y: 0 }}
                 transition={reduce ? { duration: 0 } : { duration: 0.6, delay: 0.2 }}
-                className="mt-4 w-full text-left text-base text-white text-pretty text-balance sm:text-lg"
+                className="mt-4 w-full text-left text-base text-white text-pretty text-balance sm:text-lg xl:text-xl 2xl:text-2xl"
               >
                 Un test gratuito in 5 minuti che ti apre gli occhi. E una guida basata su 500+ studi per cambiare davvero.
               </motion.p>
@@ -50,7 +50,7 @@ export default function HeroSection() {
             >
               <CTAButton
                 href="/test"
-                className="w-full max-w-full !flex justify-center !px-5 !py-3 text-base sm:w-auto sm:!px-6 sm:!py-3 sm:text-lg"
+                className="w-full max-w-full !flex justify-center !px-5 !py-3 text-base sm:w-auto sm:!px-6 sm:!py-3 sm:text-lg xl:!px-7 xl:!py-3.5 xl:text-xl"
                 onClick={() => track("cta_click_hero")}
               >
                 {CTA_COPY}
@@ -61,7 +61,7 @@ export default function HeroSection() {
               initial={{ opacity: 0, y: 20 }}
               animate={{ opacity: 1, y: 0 }}
               transition={reduce ? { duration: 0 } : { duration: 0.6, delay: 0.6 }}
-              className="mt-6 text-left text-sm text-white/80"
+              className="mt-6 text-left text-sm text-white/80 xl:text-base 2xl:text-lg"
             >
               ⭐️⭐️⭐️⭐️⭐️ 4,8/5 · 20.000+ valutazioni
             </motion.div>
@@ -71,7 +71,7 @@ export default function HeroSection() {
           initial={{ opacity: 0, y: 20 }}
           animate={{ opacity: 1, y: 0 }}
           transition={reduce ? { duration: 0 } : { duration: 0.6, delay: 0.6 }}
-          className="mt-[clamp(3rem,8vh,5rem)] w-full lg:mb-[clamp(1.5rem,4vh,3rem)]"
+          className="mt-[clamp(3rem,8vh,5rem)] w-full lg:mb-[clamp(1rem,3vh,2.5rem)] 2xl:mb-[clamp(0.5rem,2vh,1.5rem)]"
         >
           <HeroTicker />
         </motion.div>

--- a/src/components/HeroTicker.tsx
+++ b/src/components/HeroTicker.tsx
@@ -51,7 +51,7 @@ export default function HeroTicker() {
 
   return (
     <div
-      className="group relative mx-auto mt-[clamp(2rem,4vw,6rem)] w-full max-w-none overflow-hidden"
+      className="group relative mx-auto mt-[clamp(2rem,5vh,4rem)] w-full max-w-none overflow-hidden"
       style={
         {
           "--marquee-duration": "60s",

--- a/src/components/HeroTicker.tsx
+++ b/src/components/HeroTicker.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type { CSSProperties } from "react";
+import { useEffect, useMemo, useState, type CSSProperties } from "react";
 import { Brain, Gift, Key, Users } from "lucide-react";
 
 const items = [
@@ -15,18 +15,43 @@ const ACCENT_OFFSET = 3;
 const ACCENT_COLORS = ["text-white", "text-red"] as const;
 
 // Quante volte ripetere il set per OGNI metà (aumenta se servono schermi più larghi)
-const REPEATS_PER_HALF = 6;
+const BASE_REPEATS_PER_HALF = 6;
+const ESTIMATED_ITEM_WIDTH = 240; // px, usato solo per un calcolo grossolano
 
-// Costruiamo una metà molto lunga duplicando gli item
-const half = Array.from({ length: REPEATS_PER_HALF }).flatMap(() => items);
+function useResponsiveRepeats() {
+  const [repeats, setRepeats] = useState(BASE_REPEATS_PER_HALF);
 
-// Traccia completa = due metà identiche (necessario per il loop a -50%)
-const track = [...half, ...half];
+  useEffect(() => {
+    const updateRepeats = () => {
+      if (typeof window === "undefined") return;
+      const viewportWidth = window.innerWidth;
+      const estimatedNeeded = Math.ceil(viewportWidth / ESTIMATED_ITEM_WIDTH) + 2;
+
+      setRepeats(Math.max(BASE_REPEATS_PER_HALF, estimatedNeeded));
+    };
+
+    updateRepeats();
+    window.addEventListener("resize", updateRepeats);
+
+    return () => window.removeEventListener("resize", updateRepeats);
+  }, []);
+
+  return repeats;
+}
 
 export default function HeroTicker() {
+  const repeatsPerHalf = useResponsiveRepeats();
+
+  const half = useMemo(
+    () => Array.from({ length: repeatsPerHalf }).flatMap(() => items),
+    [repeatsPerHalf],
+  );
+
+  const track = useMemo(() => [...half, ...half], [half]);
+
   return (
     <div
-      className="group relative mx-auto mt-24 w-full max-w-none overflow-hidden sm:mt-28 lg:mt-28 xl:mt-32 2xl:mt-36"
+      className="group relative mx-auto mt-[clamp(2rem,4vw,6rem)] w-full max-w-none overflow-hidden"
       style={
         {
           "--marquee-duration": "60s",


### PR DESCRIPTION
## Summary
- allow the hero container to scale wider and adjust vertical spacing with clamp-based values so it stays balanced on large desktops
- make the ticker's repetition count responsive to the viewport width and smooth out its outer margins

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68d57159b66883288e98e79d8e2eac4b