### PR TITLE
Adjust Safari fallbacks for header and hero

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -6,9 +6,11 @@ import { useEffect, useRef, useState } from "react";
 import CTAButton from "./CTAButton";
 import { CTA_COPY } from "@/lib/constants";
 import { useScrollProgress } from "@/lib/useScrollProgress";
+import { useIsMobileSafari } from "@/lib/useIsMobileSafari";
 
 export default function Header() {
   const { scrolled } = useScrollProgress();
+  const isMobileSafari = useIsMobileSafari();
 
   const pathname = usePathname();
   const [isMenuOpen, setIsMenuOpen] = useState(false);
@@ -65,13 +67,17 @@ export default function Header() {
 
   return (
     <header
-      className={`fixed top-0 left-0 w-full z-50 transition-all ${
+      className={`fixed top-0 left-0 z-50 w-full transition-colors duration-300 ${
         scrolled
-          ? "backdrop-blur bg-bg/70 shadow-lg shadow-black/30"
-          : "bg-transparent"
+          ? isMobileSafari
+            ? "bg-bg/95 shadow-[0_8px_24px_rgba(0,0,0,0.32)]"
+            : "supports-[backdrop-filter]:backdrop-blur bg-bg/70 shadow-lg shadow-black/30"
+          : isMobileSafari
+            ? "bg-gradient-to-b from-black/90 via-black/80 to-transparent"
+            : "bg-transparent"
       }`}
     >
-      {!scrolled && (
+      {!scrolled && !isMobileSafari && (
         <div className="pointer-events-none absolute inset-0 bg-gradient-to-b from-black/60 to-transparent" />
       )}
 
@@ -137,7 +143,11 @@ export default function Header() {
               <div
                 id="mobile-menu"
                 role="menu"
-                className="absolute right-0 top-full mt-3 w-56 rounded-2xl border border-white/20 bg-white/10 p-1 text-white shadow-[0_18px_40px_rgba(0,0,0,0.45)] backdrop-blur-md sm:hidden"
+                className={`absolute right-0 top-full mt-3 w-56 rounded-2xl border p-1 text-white shadow-[0_18px_40px_rgba(0,0,0,0.45)] sm:hidden ${
+                  isMobileSafari
+                    ? "border-white/15 bg-[#101012]/95"
+                    : "border-white/20 bg-white/10 supports-[backdrop-filter]:backdrop-blur"
+                }`}
               >
                 <div className="flex flex-col">
                   <Link

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -3,12 +3,14 @@ import CTAButton from "@/components/CTAButton";
 import HeroTicker from "@/components/HeroTicker";
 import { CTA_COPY } from "@/lib/constants";
 import { track } from "@/lib/track";
+import { useIsMobileSafari } from "@/lib/useIsMobileSafari";
 import { motion } from "framer-motion";
 const reduce =
   typeof window !== "undefined" &&
   window.matchMedia?.("(prefers-reduced-motion: reduce)").matches;
 
 export default function HeroSection() {
+  const isMobileSafari = useIsMobileSafari();
   return (
     // isolate -> stacking context; z-0 per lo sfondo; contenuto a z-10
     <section className="relative isolate flex w-[min(100dvw,100%)] min-h-[min(100svh,70rem)] items-start overflow-hidden 2xl:min-h-[min(100svh,64rem)]">
@@ -16,7 +18,13 @@ export default function HeroSection() {
       <div className="relative z-10 w-full">
         <div className="mx-auto flex w-full max-w-[min(96rem,92vw)] flex-col items-start gap-12 px-4 pt-[clamp(3rem,8vh,5.5rem)] pb-2 sm:px-6 lg:flex-row lg:items-center lg:gap-16 xl:gap-20">
           <div className="flex w-full max-w-[32rem] flex-col items-start text-left sm:max-w-[36rem]">
-            <div className="rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs font-body text-white/90 backdrop-blur">
+            <div
+              className={`rounded-full border border-white/10 px-3 py-1 text-xs font-body text-white/90 ${
+                isMobileSafari
+                  ? "bg-white/10"
+                  : "bg-white/5 supports-[backdrop-filter]:backdrop-blur"
+              }`}
+            >
               +20.000 persone hanno già fatto il test
             </div>
 
@@ -46,7 +54,7 @@ export default function HeroSection() {
               initial={{ opacity: 0, y: 20 }}
               animate={{ opacity: 1, y: 0 }}
               transition={reduce ? { duration: 0 } : { duration: 0.6, delay: 0.4 }}
-              className="relative mt-6 w-full drop-shadow-[0_12px_30px_rgba(0,0,0,0.35)] sm:w-auto sm:self-start"
+              className="relative mt-6 w-full shadow-[0_12px_30px_rgba(0,0,0,0.35)] sm:w-auto sm:self-start"
             >
               <CTAButton
                 href="/test"

--- a/src/components/HeroTicker.tsx
+++ b/src/components/HeroTicker.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useMemo, useState, type CSSProperties } from "react";
+import { useIsMobileSafari } from "@/lib/useIsMobileSafari";
 import { Brain, Gift, Key, Users } from "lucide-react";
 
 const items = [
@@ -41,6 +42,7 @@ function useResponsiveRepeats() {
 
 export default function HeroTicker() {
   const repeatsPerHalf = useResponsiveRepeats();
+  const isMobileSafari = useIsMobileSafari();
 
   const half = useMemo(
     () => Array.from({ length: repeatsPerHalf }).flatMap(() => items),
@@ -74,7 +76,11 @@ export default function HeroTicker() {
           return (
             <div
               key={`${item.label}-${idx}`}
-              className={`pointer-events-none inline-flex shrink-0 items-center gap-2 whitespace-nowrap rounded-full border border-white/20 bg-white/10 px-4 py-2 text-sm font-body backdrop-blur-md shadow-sm lg:px-5 lg:py-2.5 lg:text-base ${accentClass}`}
+              className={`pointer-events-none inline-flex shrink-0 items-center gap-2 whitespace-nowrap rounded-full border border-white/20 px-4 py-2 text-sm font-body shadow-sm lg:px-5 lg:py-2.5 lg:text-base ${
+                isMobileSafari
+                  ? "bg-white/12"
+                  : "bg-white/10 supports-[backdrop-filter]:backdrop-blur-md"
+              } ${accentClass}`}
               aria-hidden={idx >= half.length} /* la seconda metà serve solo per il loop */
             >
               <item.icon className="h-4 w-4 text-red" />

--- a/src/components/StickyCTABar.tsx
+++ b/src/components/StickyCTABar.tsx
@@ -6,12 +6,14 @@ import CTAButton from "@/components/CTAButton";
 import { CTA_COPY } from "@/lib/constants";
 import { track } from "@/lib/track";
 import { useScrollProgress } from "@/lib/useScrollProgress";
+import { useIsMobileSafari } from "@/lib/useIsMobileSafari";
 
 export default function StickyCTABar() {
   const [mounted, setMounted] = useState(false);
   const [tracked, setTracked] = useState(false);
   const { progress, stickyThreshold } = useScrollProgress();
   const visible = progress >= stickyThreshold;
+  const isMobileSafari = useIsMobileSafari();
 
   useEffect(() => {
     setMounted(true);
@@ -26,7 +28,13 @@ export default function StickyCTABar() {
 
   const ctaContent = useMemo(
     () => (
-      <div className="pointer-events-none mx-auto w-full max-w-screen-sm rounded-2xl bg-bg/80 px-4 py-3 shadow-lg shadow-black/30 backdrop-blur supports-[backdrop-filter]:backdrop-blur sm:max-w-screen-md">
+      <div
+        className={`pointer-events-none mx-auto w-full max-w-screen-sm rounded-2xl px-4 py-3 sm:max-w-screen-md ${
+          isMobileSafari
+            ? "bg-bg/95 shadow-[0_12px_32px_rgba(0,0,0,0.4)]"
+            : "bg-bg/80 shadow-lg shadow-black/30 supports-[backdrop-filter]:backdrop-blur"
+        }`}
+      >
         <CTAButton
           href="/test"
           className="pointer-events-auto w-full max-w-full !flex justify-center !px-5 !py-3 text-base"
@@ -36,7 +44,7 @@ export default function StickyCTABar() {
         </CTAButton>
       </div>
     ),
-    [],
+    [isMobileSafari],
   );
 
   if (!mounted) {

--- a/src/lib/useIsMobileSafari.ts
+++ b/src/lib/useIsMobileSafari.ts
@@ -1,0 +1,30 @@
+import { useEffect, useState } from "react";
+
+function detectMobileSafari() {
+  if (typeof navigator === "undefined") {
+    return false;
+  }
+
+  const { userAgent } = navigator;
+  const isIOSDevice =
+    /iP(ad|hone|od)/.test(userAgent) ||
+    (userAgent.includes("Mac") && typeof document !== "undefined" && "ontouchend" in document);
+  if (!isIOSDevice) {
+    return false;
+  }
+
+  const isWebKit = /WebKit/.test(userAgent);
+  const isExcludedBrowser = /CriOS|FxiOS|OPiOS|EdgiOS|mercury/i.test(userAgent);
+
+  return isIOSDevice && isWebKit && !isExcludedBrowser;
+}
+
+export function useIsMobileSafari() {
+  const [isMobileSafari, setIsMobileSafari] = useState(false);
+
+  useEffect(() => {
+    setIsMobileSafari(detectMobileSafari());
+  }, []);
+
+  return isMobileSafari;
+}


### PR DESCRIPTION
## Summary
- add a reusable `useIsMobileSafari` hook and use it to disable backdrop blur/filters that triggered Safari artefacts
- simplify hero CTA shadow styling to rely on standard box-shadows instead of filter-based drop shadows
- tweak the sticky CTA bar and mobile menu backgrounds to provide stable rasterization on iOS Safari while preserving the desktop look

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d57815b2b48328a889651e5fe12ef6