### PR TITLE
Remove hero CTA shadows and glow

### DIFF
--- a/src/components/CTAButton.tsx
+++ b/src/components/CTAButton.tsx
@@ -35,8 +35,8 @@ export default function CTAButton({
   type = "button",
   style,
 }: Props) {
-  const base = `inline-flex items-center justify-center rounded-2xl bg-gradient-to-r from-[#FF2D2D] to-[#FF7A7A] px-5 py-2 font-body font-semibold text-fg shadow-[0_0_12px_rgba(255,45,45,0.45)] transition-all ${
-    disabled ? "cursor-not-allowed opacity-50" : "hover:to-red-dim hover:shadow-[0_0_20px_rgba(255,45,45,0.6)]"
+  const base = `inline-flex items-center justify-center rounded-2xl bg-gradient-to-r from-[#FF2D2D] to-[#FF7A7A] px-5 py-2 font-body font-semibold text-fg transition-all ${
+    disabled ? "cursor-not-allowed opacity-50" : "hover:to-red-dim"
   }`;
   const touch = isTouchDevice();
   const motionProps = disabled || touch

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -25,7 +25,7 @@ export default function HeroSection() {
                 initial={{ opacity: 0, y: 20 }}
                 animate={{ opacity: 1, y: 0 }}
                 transition={reduce ? { duration: 0 } : { duration: 0.6 }}
-                className="w-full text-left text-4xl font-bold leading-tight tracking-tight text-white text-shadow-soft sm:text-5xl md:text-6xl xl:text-7xl 2xl:text-8xl"
+                className="w-full text-left text-4xl font-bold leading-tight tracking-tight text-white sm:text-5xl md:text-6xl xl:text-7xl 2xl:text-8xl"
               >
                 <span className="block w-full whitespace-nowrap">Scopri perché le tue</span>
                 <span className="block w-full whitespace-nowrap">relazioni non</span>
@@ -46,7 +46,7 @@ export default function HeroSection() {
               initial={{ opacity: 0, y: 20 }}
               animate={{ opacity: 1, y: 0 }}
               transition={reduce ? { duration: 0 } : { duration: 0.6, delay: 0.4 }}
-              className="relative mt-6 w-full drop-shadow-[0_12px_30px_rgba(0,0,0,0.35)] sm:w-auto sm:self-start"
+              className="relative mt-6 w-full sm:w-auto sm:self-start"
             >
               <CTAButton
                 href="/test"


### PR DESCRIPTION
## Summary
- remove drop shadow and text glow classes from the hero CTA area to eliminate the flickering overlays in Safari
- strip the CTA button component of its global glow and hover shadow styling so the hero button renders without halos

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d5837713ac8328b657c567b9c4c511