### PR TITLE
Enlarge hero cards and align with ticker styling

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -57,7 +57,7 @@ body {
 
 @layer components {
   .aff-card {
-    @apply rounded-2xl border border-white/40 bg-black/30 backdrop-blur-sm shadow-[inset_0_1px_0_rgba(255,255,255,0.12)] p-6 md:p-8;
+    @apply rounded-2xl border border-white/20 bg-white/10 backdrop-blur-md shadow-[inset_0_1px_0_rgba(255,255,255,0.12)] p-6 md:p-8;
   }
 
   .aff-card h3,

--- a/src/components/HeroTicker.tsx
+++ b/src/components/HeroTicker.tsx
@@ -51,7 +51,7 @@ export default function HeroTicker() {
 
   return (
     <div
-      className="group relative mx-auto mt-[clamp(2rem,5vh,4rem)] w-full max-w-none overflow-hidden"
+      className="group relative mx-auto mt-[clamp(2rem,5vh,4rem)] w-full max-w-none overflow-hidden lg:mt-[calc(clamp(2rem,5vh,4rem)+2cm)]"
       style={
         {
           "--marquee-duration": "60s",

--- a/src/components/MiniBenefits.tsx
+++ b/src/components/MiniBenefits.tsx
@@ -48,20 +48,20 @@ const baseCard =
 
   return (
     <section className="pt-0 pb-12 sm:pt-2 sm:pb-14 lg:pt-4">
-      <Container className="max-w-[min(96rem,92vw)]">
+      <Container className="max-w-[min(108rem,92vw)]">
         <motion.div
           variants={container}
           initial="hidden"
           whileInView="show"
           viewport={{ once: true, amount: 0.2 }}
-          className="grid gap-6 md:grid-cols-2 md:gap-8"
+          className="grid gap-6 md:grid-cols-2 md:gap-10 xl:gap-12"
         >
           {items.map(({ icon: Icon, title, desc }, i) => (
             <motion.div
               key={title}
               variants={item}
               className={`${baseCard} ${
-                i === 2 ? "md:col-span-2 md:max-w-3xl md:mx-auto" : ""
+                i === 2 ? "md:col-span-2 md:mx-0 md:max-w-none" : ""
               }`}
             >
               <Icon className="h-12 w-12 text-white" />

--- a/src/components/MiniBenefits.tsx
+++ b/src/components/MiniBenefits.tsx
@@ -43,8 +43,8 @@ export default function MiniBenefits() {
     },
   } as const;
 
-const baseCard =
-  "aff-card flex flex-col gap-4 transition-transform duration-300 hover:-translate-y-1 md:p-10 xl:p-12 xl:gap-6";
+  const baseCard =
+    "aff-card flex flex-col gap-4 transition-transform duration-300 hover:-translate-y-1 md:gap-5 md:p-12 xl:gap-7 xl:p-16";
 
   return (
     <section className="pt-0 pb-12 sm:pt-2 sm:pb-14 lg:pt-4">
@@ -54,20 +54,26 @@ const baseCard =
           initial="hidden"
           whileInView="show"
           viewport={{ once: true, amount: 0.2 }}
-          className="grid gap-6 md:grid-cols-2 md:gap-10 xl:gap-12"
+          className="grid gap-6 md:grid-cols-2 md:gap-12 xl:gap-16"
         >
           {items.map(({ icon: Icon, title, desc }, i) => (
             <motion.div
               key={title}
               variants={item}
               className={`${baseCard} ${
-                i === 2 ? "md:col-span-2 md:mx-0 md:max-w-none" : ""
+                i === 2
+                  ? "md:col-span-2 md:mx-auto md:max-w-4xl xl:max-w-5xl"
+                  : ""
               }`}
             >
-              <Icon className="h-12 w-12 text-white" />
+              <Icon className="h-12 w-12 text-white md:h-14 md:w-14" />
               <div>
-                <h3 className="font-body text-2xl font-semibold text-white">{title}</h3>
-                <p className="mt-2 text-base leading-relaxed text-white/80">{desc}</p>
+                <h3 className="font-body text-2xl font-semibold text-white md:text-[1.75rem]">
+                  {title}
+                </h3>
+                <p className="mt-2 text-base leading-relaxed text-white/80 md:text-lg md:leading-relaxed">
+                  {desc}
+                </p>
               </div>
             </motion.div>
           ))}

--- a/src/components/MiniBenefits.tsx
+++ b/src/components/MiniBenefits.tsx
@@ -44,30 +44,30 @@ export default function MiniBenefits() {
   } as const;
 
 const baseCard =
-  "aff-card flex flex-col gap-4 transition-transform duration-300 hover:-translate-y-1";
+  "aff-card flex flex-col gap-4 transition-transform duration-300 hover:-translate-y-1 md:p-10 xl:p-12 xl:gap-6";
 
   return (
     <section className="pt-0 pb-12 sm:pt-2 sm:pb-14 lg:pt-4">
-      <Container>
+      <Container className="max-w-[min(96rem,92vw)]">
         <motion.div
           variants={container}
           initial="hidden"
           whileInView="show"
           viewport={{ once: true, amount: 0.2 }}
-          className="mx-auto grid gap-6 md:grid-cols-2"
+          className="grid gap-6 md:grid-cols-2 md:gap-8"
         >
           {items.map(({ icon: Icon, title, desc }, i) => (
             <motion.div
               key={title}
               variants={item}
               className={`${baseCard} ${
-                i === 2 ? "md:col-span-2 md:max-w-2xl md:mx-auto" : ""
+                i === 2 ? "md:col-span-2 md:max-w-3xl md:mx-auto" : ""
               }`}
             >
-              <Icon className="h-10 w-10 text-white" />
+              <Icon className="h-12 w-12 text-white" />
               <div>
-                <h3 className="font-body text-xl font-semibold text-white">{title}</h3>
-                <p className="mt-1 text-sm leading-relaxed text-white/80">{desc}</p>
+                <h3 className="font-body text-2xl font-semibold text-white">{title}</h3>
+                <p className="mt-2 text-base leading-relaxed text-white/80">{desc}</p>
               </div>
             </motion.div>
           ))}

--- a/src/components/ProsConsSection.tsx
+++ b/src/components/ProsConsSection.tsx
@@ -12,19 +12,21 @@ export default function ProsConsSection() {
     transition: { duration: 0.6 },
   } as const;
   const card =
-    "aff-card relative overflow-hidden text-center transition-transform hover:-translate-y-1 md:text-left";
+    "aff-card relative overflow-hidden text-center transition-transform hover:-translate-y-1 md:text-left md:p-10 xl:p-12";
   return (
     <motion.section
       id="perche-affinity"
       className="py-10 sm:py-14 scroll-mt-16 md:scroll-mt-20"
       {...sectionProps}
     >
-      <Container className="text-center">
-        <h2 className="font-heading font-bold tracking-[-0.5px] text-3xl">Perché Affinity è diverso da tutto il resto</h2>
-        <p className="mx-auto mt-4 max-w-2xl text-white">
-          Niente opinioni. Solo ciò che la scienza e l’esperienza reale dimostrano.
-        </p>
-        <div className="mt-12 grid gap-8 md:grid-cols-2 md:gap-6">
+      <Container className="max-w-[min(96rem,92vw)]">
+        <div className="text-center">
+          <h2 className="font-heading font-bold tracking-[-0.5px] text-3xl">Perché Affinity è diverso da tutto il resto</h2>
+          <p className="mx-auto mt-4 max-w-2xl text-white">
+            Niente opinioni. Solo ciò che la scienza e l’esperienza reale dimostrano.
+          </p>
+        </div>
+        <div className="mt-12 grid gap-8 md:grid-cols-2 md:gap-8">
           <motion.div
             className={card}
             {...{ transition: { delay: 0.1 } }}
@@ -34,7 +36,7 @@ export default function ProsConsSection() {
               <X className="h-10 w-10 text-white animate-icon-bounce" />
             </div>
             <h3 className="font-body font-semibold text-white">Problemi</h3>
-            <ul className="mt-4 space-y-2 text-sm text-white/80 text-left">
+            <ul className="mt-4 space-y-3 text-base text-white/80 text-left">
               <li>Attiri sempre le persone sbagliate e finisce nello stesso modo.</li>
               <li>Dopo poco perdono interesse e non capisci perché.</li>
               <li>Su Google e TikTok trovi solo consigli banali e contraddittori.</li>
@@ -51,7 +53,7 @@ export default function ProsConsSection() {
               <Check className="h-10 w-10 text-white animate-icon-bounce" />
             </div>
             <h3 className="font-body font-semibold text-white">Soluzioni</h3>
-            <ul className="mt-4 space-y-2 text-sm text-white/80 text-left">
+            <ul className="mt-4 space-y-3 text-base text-white/80 text-left">
               <li>Scopri subito perché ti accade sempre lo stesso schema.</li>
               <li>Capisci i tuoi errori nascosti e come smettere di ripeterli.</li>
               <li>Accedi alla Guida Premium: 500+ libri e studi tradotti in strategie chiare.</li>

--- a/src/components/ProsConsSection.tsx
+++ b/src/components/ProsConsSection.tsx
@@ -19,14 +19,14 @@ export default function ProsConsSection() {
       className="py-10 sm:py-14 scroll-mt-16 md:scroll-mt-20"
       {...sectionProps}
     >
-      <Container className="max-w-[min(96rem,92vw)]">
+      <Container className="max-w-[min(108rem,92vw)]">
         <div className="text-center">
           <h2 className="font-heading font-bold tracking-[-0.5px] text-3xl">Perché Affinity è diverso da tutto il resto</h2>
           <p className="mx-auto mt-4 max-w-2xl text-white">
             Niente opinioni. Solo ciò che la scienza e l’esperienza reale dimostrano.
           </p>
         </div>
-        <div className="mt-12 grid gap-8 md:grid-cols-2 md:gap-8">
+        <div className="mt-12 grid gap-8 md:grid-cols-2 md:gap-10 xl:gap-12">
           <motion.div
             className={card}
             {...{ transition: { delay: 0.1 } }}


### PR DESCRIPTION
## Summary
- match the shared card styling with the lighter ticker chip appearance
- enlarge the mini benefit cards and adjust their layout so they align with the hero heading width
- scale up the pros/cons cards with wider spacing and typography for better balance

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d58db4c80c83289db52d488f3a1460