### PR TITLE
Adjust hero and card containers for mobile alignment

### DIFF
--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -14,7 +14,7 @@ export default function HeroSection() {
     <section className="relative isolate flex w-[min(100dvw,100%)] min-h-[min(100svh,70rem)] items-start overflow-hidden 2xl:min-h-[min(100svh,64rem)]">
 
       <div className="relative z-10 w-full">
-        <div className="mx-auto flex w-full max-w-[min(96rem,92vw)] flex-col items-start gap-12 px-4 pt-[clamp(3rem,8vh,5.5rem)] pb-2 sm:px-6 lg:flex-row lg:items-center lg:gap-16 xl:gap-20">
+        <div className="mx-0 flex w-full max-w-none flex-col items-start gap-12 px-4 pt-[clamp(3rem,8vh,5.5rem)] pb-2 sm:mx-auto sm:max-w-[min(96rem,92vw)] sm:px-6 lg:flex-row lg:items-center lg:gap-16 xl:gap-20">
           <div className="flex w-full max-w-[32rem] flex-col items-start text-left sm:max-w-[36rem]">
             <div className="rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs font-body text-white/90 backdrop-blur">
               +20.000 persone hanno già fatto il test

--- a/src/components/MiniBenefits.tsx
+++ b/src/components/MiniBenefits.tsx
@@ -48,7 +48,7 @@ export default function MiniBenefits() {
 
   return (
     <section className="pt-0 pb-12 sm:pt-2 sm:pb-14 lg:pt-4">
-      <Container className="max-w-[min(108rem,92vw)]">
+      <Container className="max-w-none sm:max-w-[min(108rem,92vw)]">
         <motion.div
           variants={container}
           initial="hidden"

--- a/src/components/ProsConsSection.tsx
+++ b/src/components/ProsConsSection.tsx
@@ -19,7 +19,7 @@ export default function ProsConsSection() {
       className="py-10 sm:py-14 scroll-mt-16 md:scroll-mt-20"
       {...sectionProps}
     >
-      <Container className="max-w-[min(108rem,92vw)]">
+      <Container className="max-w-none sm:max-w-[min(108rem,92vw)]">
         <div className="text-center">
           <h2 className="font-heading font-bold tracking-[-0.5px] text-3xl">Perché Affinity è diverso da tutto il resto</h2>
           <p className="mx-auto mt-4 max-w-2xl text-white">


### PR DESCRIPTION
## Summary
- remove mobile max-width constraints from the hero wrapper so content aligns flush with the logo before the sm breakpoint
- match MiniBenefits and ProsCons container widths so the cards share the same layout rules across viewports

## Testing
- npm run dev (visual verification at 375px viewport)


------
https://chatgpt.com/codex/tasks/task_e_68d6481d3f948328aaf73258a8503d31