### PR TITLE
Adjust footer layout and update Instagram link

### DIFF
--- a/src/components/SiteFooter.tsx
+++ b/src/components/SiteFooter.tsx
@@ -5,8 +5,8 @@ export default function SiteFooter() {
     <footer className="relative text-xs text-white">
       <div className="pointer-events-none absolute inset-x-0 top-0 h-px bg-white/10" />
       <div className="pointer-events-none absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-red/40 to-transparent blur-sm" />
-      <div className="mx-auto max-w-container px-4 py-6 md:grid md:grid-cols-3 md:items-center md:gap-4">
-        <div className="flex flex-col items-center gap-2 md:flex-row md:justify-start md:gap-6">
+      <div className="mx-auto max-w-container px-4 py-6 md:flex md:items-center md:gap-6">
+        <div className="order-1 flex flex-col items-center gap-2 md:order-1 md:flex-row md:items-center md:gap-6">
           <Link
             href="/privacy"
             className="px-2 py-2 text-white hover:text-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-red"
@@ -20,12 +20,9 @@ export default function SiteFooter() {
             Termini
           </Link>
         </div>
-        <p className="mt-4 text-center text-white md:mt-0">
-          Affinity — basato su oltre 500 libri, studi e meta-analisi sulle relazioni.
-        </p>
-        <div className="mt-4 flex justify-center md:mt-0 md:justify-end">
+        <div className="order-2 mt-4 flex justify-center md:order-3 md:mt-0 md:ml-auto md:justify-end">
           <a
-            href="https://instagram.com/getaffinity"
+            href="https://www.instagram.com/affinity.it?igsh=MXJ3bDJuM3pxdjNlbQ=="
             target="_blank"
             rel="noreferrer"
             className="px-2 py-2 text-white hover:text-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-red"
@@ -33,6 +30,9 @@ export default function SiteFooter() {
             Instagram @getaffinity
           </a>
         </div>
+        <p className="order-3 mt-4 text-center text-white md:order-2 md:mt-0 md:flex-1">
+          Affinity — basato su oltre 500 libri, studi e meta-analisi sulle relazioni.
+        </p>
       </div>
     </footer>
   );

--- a/src/components/SiteFooter.tsx
+++ b/src/components/SiteFooter.tsx
@@ -5,8 +5,8 @@ export default function SiteFooter() {
     <footer className="relative text-xs text-white">
       <div className="pointer-events-none absolute inset-x-0 top-0 h-px bg-white/10" />
       <div className="pointer-events-none absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-red/40 to-transparent blur-sm" />
-      <div className="mx-auto max-w-container px-4 py-6 md:flex md:items-center md:gap-6">
-        <div className="order-1 flex flex-col items-center gap-2 md:order-1 md:flex-row md:items-center md:gap-6">
+      <div className="mx-auto max-w-container px-4 py-6 md:grid md:grid-cols-[auto,1fr,auto] md:items-center">
+        <div className="order-1 flex flex-col items-center gap-2 md:order-1 md:flex-row md:items-center md:gap-6 md:justify-self-start">
           <Link
             href="/privacy"
             className="px-2 py-2 text-white hover:text-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-red"
@@ -20,17 +20,17 @@ export default function SiteFooter() {
             Termini
           </Link>
         </div>
-        <div className="order-2 mt-4 flex justify-center md:order-3 md:mt-0 md:ml-auto md:justify-end">
+        <div className="order-2 mt-4 flex justify-center md:order-3 md:mt-0 md:justify-self-end">
           <a
             href="https://www.instagram.com/affinity.it?igsh=MXJ3bDJuM3pxdjNlbQ=="
             target="_blank"
             rel="noreferrer"
             className="px-2 py-2 text-white hover:text-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-red"
           >
-            Instagram @getaffinity
+            Instagram
           </a>
         </div>
-        <p className="order-3 mt-4 text-center text-white md:order-2 md:mt-0 md:flex-1">
+        <p className="order-3 mt-4 text-center text-white md:order-2 md:mt-0">
           Affinity — basato su oltre 500 libri, studi e meta-analisi sulle relazioni.
         </p>
       </div>


### PR DESCRIPTION
## Summary
- realign the footer links so Privacy/Termini stay on the left, Instagram on the right, and the tagline remains centered on desktop
- reorder the footer links on mobile so the Instagram link appears above the tagline
- update the Instagram footer link to the requested affinity.it profile URL

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d64cf87ff08328b843bc9887ca8f5e