### PR TITLE
Add parallax and shine effects to hero illustration

### DIFF
--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -3,16 +3,27 @@ import CTAButton from "@/components/CTAButton";
 import HeroTicker from "@/components/HeroTicker";
 import { CTA_COPY } from "@/lib/constants";
 import { track } from "@/lib/track";
-import { motion } from "framer-motion";
+import { motion, useScroll, useTransform } from "framer-motion";
 import Image from "next/image";
+import { useRef } from "react";
 const reduce =
   typeof window !== "undefined" &&
   window.matchMedia?.("(prefers-reduced-motion: reduce)").matches;
 
 export default function HeroSection() {
+  const sectionRef = useRef<HTMLElement | null>(null);
+  const { scrollYProgress } = useScroll({
+    target: sectionRef,
+    offset: ["start end", "end start"],
+  });
+  const parallaxY = useTransform(scrollYProgress, [0, 1], [0, 24]);
+
   return (
     // isolate -> stacking context; z-0 per lo sfondo; contenuto a z-10
-    <section className="relative isolate flex w-[min(100dvw,100%)] min-h-[min(100svh,70rem)] items-start overflow-hidden 2xl:min-h-[min(100svh,64rem)]">
+    <section
+      ref={sectionRef}
+      className="relative isolate flex w-[min(100dvw,100%)] min-h-[min(100svh,70rem)] items-start overflow-hidden 2xl:min-h-[min(100svh,64rem)]"
+    >
 
       <div className="relative z-10 w-full">
         <div className="mx-0 flex w-full max-w-none flex-col items-start gap-12 px-4 pt-[clamp(3rem,8vh,5.5rem)] pb-2 sm:mx-auto sm:max-w-[min(96rem,92vw)] sm:px-6 lg:flex-row lg:items-center lg:justify-between lg:gap-16 xl:gap-20">
@@ -68,16 +79,44 @@ export default function HeroSection() {
             </motion.div>
           </div>
 
-          <div className="hidden shrink-0 grow-0 lg:flex lg:w-full lg:max-w-[28rem] xl:max-w-[32rem] 2xl:max-w-[36rem]">
-            <Image
-              src="/connessione.png"
-              alt="Connessione"
-              width={640}
-              height={640}
-              className="h-auto w-full"
-              priority
-            />
-          </div>
+          <motion.div
+            style={{ y: reduce ? 0 : parallaxY }}
+            className="hidden shrink-0 grow-0 lg:flex lg:w-full lg:max-w-[28rem] xl:max-w-[32rem] 2xl:max-w-[36rem]"
+          >
+            <motion.div
+              animate={reduce ? { y: 0 } : { y: [0, -12, 0] }}
+              transition={
+                reduce
+                  ? { duration: 0 }
+                  : { duration: 6, repeat: Infinity, ease: "easeInOut" }
+              }
+              className="relative h-full w-full"
+            >
+              <Image
+                src="/connessione.png"
+                alt="Connessione"
+                width={640}
+                height={640}
+                className="h-auto w-full"
+                priority
+              />
+              <motion.div
+                aria-hidden
+                animate={reduce ? { opacity: 0 } : { opacity: [0, 0, 0.35, 0] }}
+                transition={
+                  reduce
+                    ? { duration: 0 }
+                    : {
+                        duration: 2,
+                        repeat: Infinity,
+                        repeatDelay: 8,
+                        ease: "easeInOut",
+                      }
+                }
+                className="pointer-events-none absolute inset-0 rounded-[2rem] bg-[radial-gradient(circle_at_top,rgba(255,255,255,0.35),transparent_55%)] opacity-0 mix-blend-screen"
+              />
+            </motion.div>
+          </motion.div>
         </div>
         <motion.div
           initial={{ opacity: 0, y: 20 }}
@@ -88,16 +127,44 @@ export default function HeroSection() {
           <HeroTicker />
         </motion.div>
 
-        <div className="mt-8 w-full px-4 sm:px-6 lg:hidden">
-          <Image
-            src="/connessione.png"
-            alt="Connessione"
-            width={640}
-            height={640}
-            className="mx-auto h-auto w-full max-w-[24rem]"
-            priority
-          />
-        </div>
+        <motion.div
+          style={{ y: reduce ? 0 : parallaxY }}
+          className="mt-8 w-full px-4 sm:px-6 lg:hidden"
+        >
+          <motion.div
+            animate={reduce ? { y: 0 } : { y: [0, -12, 0] }}
+            transition={
+              reduce
+                ? { duration: 0 }
+                : { duration: 6, repeat: Infinity, ease: "easeInOut" }
+            }
+            className="relative"
+          >
+            <Image
+              src="/connessione.png"
+              alt="Connessione"
+              width={640}
+              height={640}
+              className="mx-auto h-auto w-full max-w-[24rem]"
+              priority
+            />
+            <motion.div
+              aria-hidden
+              animate={reduce ? { opacity: 0 } : { opacity: [0, 0, 0.35, 0] }}
+              transition={
+                reduce
+                  ? { duration: 0 }
+                  : {
+                      duration: 2,
+                      repeat: Infinity,
+                      repeatDelay: 8,
+                      ease: "easeInOut",
+                    }
+              }
+              className="pointer-events-none absolute inset-0 rounded-[2rem] bg-[radial-gradient(circle_at_top,rgba(255,255,255,0.35),transparent_55%)] opacity-0 mix-blend-screen"
+            />
+          </motion.div>
+        </motion.div>
       </div>
     </section>
   );


### PR DESCRIPTION
## Summary
- add scroll-driven parallax wrapper for the hero illustration
- apply looping float motion and timed shine overlay with reduced-motion fallback
- reuse the animation stack for both desktop and mobile hero images

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d65d32ae6083289bb9cc7274f9ed97