### PR TITLE
Adjust test page layout spacing and footer visibility

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -39,6 +39,10 @@ body {
   overscroll-behavior: none;
 }
 
+body.hide-test-footer footer {
+  display: none;
+}
+
 @layer base {
   h1,
   h2,

--- a/src/app/test/page.tsx
+++ b/src/app/test/page.tsx
@@ -37,6 +37,11 @@ export default function TestPage() {
   const [showResume, setShowResume] = useState(false);
 
   useEffect(() => {
+    document.body.classList.add("hide-test-footer");
+    return () => document.body.classList.remove("hide-test-footer");
+  }, []);
+
+  useEffect(() => {
     const stored = localStorage.getItem("affinity.answers.v1");
     if (stored) {
       try {
@@ -121,7 +126,7 @@ export default function TestPage() {
   return (
     <PageTransition>
       <EventPing name="test_start" />
-      <section className="py-12">
+      <section className="pb-12 pt-10 lg:pb-16 lg:pt-28">
         <Container className="flex flex-col items-center">
           {showResume && (
             <div className="mb-4 flex w-full max-w-[740px] items-center justify-between rounded-md border border-border bg-bg p-4 text-sm">
@@ -136,7 +141,7 @@ export default function TestPage() {
               </div>
             </div>
           )}
-          <Card className="w-full max-w-[740px] space-y-8">
+          <Card className="w-full max-w-[780px] space-y-8 lg:max-w-[960px]">
             <div className="sticky top-0 z-10 pb-4">
               <ProgressBar current={current + 1} total={total} />
               <p className="mt-2 text-sm" aria-live="polite">

--- a/src/components/QuestionStep.tsx
+++ b/src/components/QuestionStep.tsx
@@ -21,18 +21,18 @@ export default function QuestionStep({
 }) {
   return (
     <div className="space-y-6">
-      <div className="text-sm text-muted">{question.category}</div>
-      <h2 className="flex items-start gap-2 text-2xl font-bold">
-        <span className="text-2xl opacity-80 shrink-0">{question.icon}</span>
+      <div className="text-sm text-muted lg:text-base">{question.category}</div>
+      <h2 className="flex items-start gap-2 text-2xl font-bold lg:text-3xl">
+        <span className="shrink-0 text-2xl opacity-80 lg:text-3xl">{question.icon}</span>
         <span className="break-words">{question.text}</span>
       </h2>
-      <div className="flex flex-col gap-3">
+      <div className="flex flex-col gap-3 lg:gap-4">
         {question.options.map((opt, i) => (
           <motion.button
             key={opt.label}
             whileTap={{ scale: 0.97 }}
             onClick={() => onSelect(i + 1)}
-            className={`flex w-full items-center justify-between rounded-full border px-4 py-3 text-left text-sm transition-colors ${
+            className={`flex w-full items-center justify-between rounded-full border px-4 py-3 text-left text-sm transition-colors lg:px-6 lg:py-4 lg:text-base ${
               answer === i + 1
                 ? "border-red bg-red text-fg"
                 : "border-border bg-transparent"


### PR DESCRIPTION
## Summary
- expand the test question card and adjust desktop spacing for a more balanced layout
- hide the global footer while on the test flow to remove the extra mobile scroll gap

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d65f7ffdc88328a38b3363bdc3de67