### PR TITLE
Wrap results summary in Card

### DIFF
--- a/src/app/risultati/page.tsx
+++ b/src/app/risultati/page.tsx
@@ -5,6 +5,7 @@ import PageTransition from "@/components/PageTransition";
 import Container from "@/components/Container";
 import CTAButton from "@/components/CTAButton";
 import ProgressRing from "@/components/ProgressRing";
+import Card from "@/components/Card";
 import { FileText } from "lucide-react";
 import EventPing from "@/components/EventPing";
 import { track } from "@/lib/track";
@@ -128,8 +129,18 @@ export default function ResultsPage() {
       <EventPing name="result_view" params={{ profile: profile.name }} />
       <section className="py-12">
         <Container className="max-w-[740px] space-y-8">
-          <h1 className="text-3xl font-bold">Il tuo profilo: {profile.name}</h1>
-          <p className="text-lg">{profile.desc}</p>
+          <Card className="space-y-3">
+            <h1 className="text-3xl font-semibold text-white">Il tuo profilo: {profile.name}</h1>
+            <p className="text-lg leading-relaxed text-white/80">{profile.desc}</p>
+            <ul className="list-disc space-y-2 pl-5 text-white/80">
+              {profile.bullets.map((b) => (
+                <li key={b.text} className="leading-relaxed">
+                  <span className="mr-1 text-white">{b.icon}</span>
+                  {b.text}
+                </li>
+              ))}
+            </ul>
+          </Card>
           <div className="flex justify-between gap-8 overflow-x-auto">
             {rings.map((r) => (
               <ProgressRing
@@ -141,14 +152,6 @@ export default function ResultsPage() {
               />
             ))}
           </div>
-          <ul className="list-disc space-y-2 pl-5 text-muted">
-            {profile.bullets.map((b) => (
-              <li key={b.text}>
-                <span className="mr-1">{b.icon}</span>
-                {b.text}
-              </li>
-            ))}
-          </ul>
           <div className="pt-4">
             <CTAButton
               onClick={handleCheckout}


### PR DESCRIPTION
## Summary
- import the shared Card component on the results page
- wrap the profile headline, description, and bullet list in a styled card to mirror the homepage look
- adjust typography classes to match existing card styling

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d68c0e97348328890ca0da316ed3d7