### PR TITLE
Switch site to light theme

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3,10 +3,10 @@
 @tailwind utilities;
 
 :root {
-  --bg: #050506;
-  --fg: #FFFFFF;
-  --muted: #B9BDC7;
-  --border: #1F1F1F;
+  --bg: #ffffff;
+  --fg: #111827;
+  --muted: #4b5563;
+  --border: #e5e7eb;
   --red: #FF2D2D;
   --red-dim: #FF7A7A;
   --font-heading: var(--font-inter, sans-serif);
@@ -29,7 +29,7 @@ html {
 }
 
 body {
-  background: transparent !important;
+  background: var(--bg) !important;
   min-height: 100%;
   margin: 0;
   padding: 0;
@@ -61,27 +61,27 @@ body.hide-test-footer footer {
 
 @layer components {
   .aff-card {
-    @apply rounded-2xl border border-white/20 bg-white/10 backdrop-blur-md shadow-[inset_0_1px_0_rgba(255,255,255,0.12)] p-6 md:p-8;
+    @apply rounded-2xl border border-neutral-200 bg-neutral-50 shadow-sm p-6 md:p-8;
   }
 
   .aff-card h3,
   .aff-card h4,
   .aff-card h5 {
-    @apply text-white;
+    @apply text-neutral-900;
   }
 
   .aff-card p,
   .aff-card .subtext,
   .aff-card li {
-    @apply text-white/80;
+    @apply text-neutral-600;
   }
 
   .aff-card svg {
-    @apply text-white;
+    @apply text-neutral-800;
   }
 
   .aff-card :is([class*="text-red-"], [class*="fill-red-"], [class*="stroke-red-"]) {
-    @apply text-white;
+    @apply text-neutral-900;
   }
 }
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,7 +2,6 @@ import type { Metadata } from "next";
 import Script from "next/script";
 import { Inter, Manrope, Poppins } from "next/font/google";
 import "./globals.css";
-import dynamic from "next/dynamic";
 import Header from "@/components/Header";
 import SiteFooter from "@/components/SiteFooter";
 
@@ -21,11 +20,6 @@ const poppins = Poppins({
   weight: ["700"],
   variable: "--font-poppins",
 });
-
-const BackgroundGradient = dynamic(
-  () => import("@/components/BackgroundGradient"),
-  { ssr: false },
-);
 
 export const metadata: Metadata = {
   title: "Affinity",
@@ -68,7 +62,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             />
           </noscript>
         ) : null}
-        <BackgroundGradient />
+        <div className="fixed inset-0 -z-10 bg-white" aria-hidden />
         <Header />
         <main className="flex-1 min-w-0">{children}</main>
         <SiteFooter />

--- a/src/app/risultati/page.tsx
+++ b/src/app/risultati/page.tsx
@@ -130,12 +130,14 @@ export default function ResultsPage() {
       <section className="py-12">
         <Container className="max-w-[740px] space-y-8">
           <Card className="space-y-3">
-            <h1 className="text-3xl font-semibold text-white">Il tuo profilo: {profile.name}</h1>
-            <p className="text-lg leading-relaxed text-white/80">{profile.desc}</p>
-            <ul className="list-disc space-y-2 pl-5 text-white/80">
+            <h1 className="text-3xl font-semibold text-neutral-900">
+              Il tuo profilo: {profile.name}
+            </h1>
+            <p className="text-lg leading-relaxed text-neutral-600">{profile.desc}</p>
+            <ul className="list-disc space-y-2 pl-5 text-neutral-600">
               {profile.bullets.map((b) => (
                 <li key={b.text} className="leading-relaxed">
-                  <span className="mr-1 text-white">{b.icon}</span>
+                  <span className="mr-1 text-neutral-900">{b.icon}</span>
                   {b.text}
                 </li>
               ))}

--- a/src/components/AgainstGurus.tsx
+++ b/src/components/AgainstGurus.tsx
@@ -16,14 +16,14 @@ export default function AgainstGurus() {
     <motion.section className="py-10 sm:py-14" {...sectionProps}>
       <Container className="flex justify-center">
         <div className="aff-card relative max-w-5xl text-center">
-          <BadgeDollarSign className="mx-auto mb-6 h-8 w-8 text-white" />
-          <h2 className="text-center font-heading text-3xl font-bold leading-tight text-white sm:text-4xl">
+          <BadgeDollarSign className="mx-auto mb-6 h-8 w-8 text-red" />
+          <h2 className="text-center font-heading text-3xl font-bold leading-tight text-neutral-900 sm:text-4xl">
             Perché non è l’ennesimo corso da 1500€
           </h2>
-          <p className="mx-auto mt-4 max-w-3xl leading-relaxed text-white/80">
+          <p className="mx-auto mt-4 max-w-3xl leading-relaxed text-neutral-600">
             I guru ti vendono promesse vaghe e corsi costosi pieni di fuffa.
-            Noi abbiamo condensato il meglio da <span className="font-semibold text-white">500+ studi</span> di psicologia in un percorso chiaro e applicabile da subito.
-            Nessun filler — <span className="font-semibold text-white">solo ciò che funziona davvero</span>.
+            Noi abbiamo condensato il meglio da <span className="font-semibold text-neutral-900">500+ studi</span> di psicologia in un percorso chiaro e applicabile da subito.
+            Nessun filler — <span className="font-semibold text-neutral-900">solo ciò che funziona davvero</span>.
           </p>
         </div>
       </Container>

--- a/src/components/FAQSection.tsx
+++ b/src/components/FAQSection.tsx
@@ -43,22 +43,24 @@ export default function FAQSection() {
       {...sectionProps}
     >
       <Container>
-        <h2 className="text-center font-heading font-bold tracking-[-0.5px] text-3xl">Domande frequenti</h2>
+        <h2 className="text-center font-heading text-3xl font-bold tracking-[-0.5px] text-neutral-900">
+          Domande frequenti
+        </h2>
         <div className="mx-auto mt-8 max-w-3xl space-y-4">
           {faqs.map((f, i) => {
             const isOpen = open === i;
             return (
               <div key={f.q} className="aff-card space-y-2">
                 <button
-                  className="flex w-full items-center justify-between text-left font-body text-white"
+                  className="flex w-full items-center justify-between text-left font-body text-neutral-900"
                   onClick={() => setOpen(isOpen ? null : i)}
                 >
                   <span className="flex items-center gap-2">
-                    <HelpCircle className="h-5 w-5 text-white animate-icon-bounce" />
+                    <HelpCircle className="h-5 w-5 text-red animate-icon-bounce" />
                     {f.q}
                   </span>
                   <motion.span animate={{ rotate: isOpen ? 180 : 0 }}>
-                    <ChevronDown className="h-4 w-4 text-white" />
+                    <ChevronDown className="h-4 w-4 text-neutral-700" />
                   </motion.span>
                 </button>
                 <motion.div
@@ -66,7 +68,7 @@ export default function FAQSection() {
                   animate={{ height: isOpen ? "auto" : 0, opacity: isOpen ? 1 : 0 }}
                   className="overflow-hidden"
                 >
-                  <p className="mt-2 text-sm text-white/80">{f.a}</p>
+                  <p className="mt-2 text-sm text-neutral-600">{f.a}</p>
                 </motion.div>
               </div>
             );

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -104,7 +104,7 @@ export default function Header() {
               aria-expanded={isMenuOpen}
               aria-controls="mobile-menu"
               onClick={() => setIsMenuOpen((prev) => !prev)}
-              className="flex h-12 w-12 items-center justify-center text-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-red"
+              className="flex h-12 w-12 items-center justify-center text-neutral-900 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-red"
             >
               <svg
                 className="h-7 w-7"
@@ -137,28 +137,28 @@ export default function Header() {
               <div
                 id="mobile-menu"
                 role="menu"
-                className="absolute right-0 top-full mt-3 w-56 rounded-2xl border border-white/20 bg-white/10 p-1 text-white shadow-[0_18px_40px_rgba(0,0,0,0.45)] backdrop-blur-md sm:hidden"
+                className="absolute right-0 top-full mt-3 w-56 rounded-2xl border border-neutral-200 bg-white p-1 text-neutral-900 shadow-lg sm:hidden"
               >
                 <div className="flex flex-col">
                   <Link
                     ref={firstMenuItemRef}
                     href="/test"
                     role="menuitem"
-                    className="rounded-xl px-4 py-3 text-base font-medium transition hover:bg-white/10 focus-visible:bg-white/10"
+                    className="rounded-xl px-4 py-3 text-base font-medium transition hover:bg-neutral-100 focus-visible:bg-neutral-100"
                   >
                     Inizia il test gratuito
                   </Link>
                   <Link
                     href="/privacy"
                     role="menuitem"
-                    className="rounded-xl px-4 py-3 text-base font-medium transition hover:bg-white/10 focus-visible:bg-white/10"
+                    className="rounded-xl px-4 py-3 text-base font-medium transition hover:bg-neutral-100 focus-visible:bg-neutral-100"
                   >
                     Privacy
                   </Link>
                   <Link
                     href="/come-funziona"
                     role="menuitem"
-                    className="rounded-xl px-4 py-3 text-base font-medium transition hover:bg-white/10 focus-visible:bg-white/10"
+                    className="rounded-xl px-4 py-3 text-base font-medium transition hover:bg-neutral-100 focus-visible:bg-neutral-100"
                   >
                     Come funziona
                   </Link>

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -28,7 +28,7 @@ export default function HeroSection() {
       <div className="relative z-10 w-full">
         <div className="mx-0 flex w-full max-w-none flex-col items-start gap-12 px-4 pt-[clamp(3rem,8vh,5.5rem)] pb-2 sm:mx-auto sm:max-w-[min(96rem,92vw)] sm:px-6 lg:flex-row lg:items-center lg:justify-between lg:gap-16 xl:gap-20">
           <div className="flex w-full max-w-[32rem] flex-col items-start text-left sm:max-w-[36rem]">
-            <div className="rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs font-body text-white/90 backdrop-blur">
+            <div className="rounded-full border border-neutral-200 bg-white px-3 py-1 text-xs font-body text-neutral-700">
               +20.000 persone hanno già fatto il test
             </div>
 
@@ -37,7 +37,7 @@ export default function HeroSection() {
                 initial={{ opacity: 0, y: 20 }}
                 animate={{ opacity: 1, y: 0 }}
                 transition={reduce ? { duration: 0 } : { duration: 0.6 }}
-                className="w-full text-left text-4xl font-bold leading-tight tracking-tight text-white sm:text-5xl md:text-6xl xl:text-7xl 2xl:text-8xl"
+                className="w-full text-left text-4xl font-bold leading-tight tracking-tight text-neutral-900 sm:text-5xl md:text-6xl xl:text-7xl 2xl:text-8xl"
               >
                 <span className="block w-full whitespace-nowrap">Scopri perché le tue</span>
                 <span className="block w-full whitespace-nowrap">relazioni non</span>
@@ -48,7 +48,7 @@ export default function HeroSection() {
                 initial={{ opacity: 0, y: 20 }}
                 animate={{ opacity: 1, y: 0 }}
                 transition={reduce ? { duration: 0 } : { duration: 0.6, delay: 0.2 }}
-                className="mt-4 w-full text-left text-base text-white text-pretty text-balance sm:text-lg xl:text-xl 2xl:text-2xl"
+                className="mt-4 w-full text-left text-base text-neutral-700 text-pretty text-balance sm:text-lg xl:text-xl 2xl:text-2xl"
               >
                 Un test gratuito in 5 minuti che ti apre gli occhi. E una guida basata su 500+ studi per cambiare davvero.
               </motion.p>
@@ -73,7 +73,7 @@ export default function HeroSection() {
               initial={{ opacity: 0, y: 20 }}
               animate={{ opacity: 1, y: 0 }}
               transition={reduce ? { duration: 0 } : { duration: 0.6, delay: 0.6 }}
-              className="mt-6 text-left text-sm text-white/80 xl:text-base 2xl:text-lg"
+              className="mt-6 text-left text-sm text-neutral-600 xl:text-base 2xl:text-lg"
             >
               ⭐️⭐️⭐️⭐️⭐️ 4,8/5 · 20.000+ valutazioni
             </motion.div>

--- a/src/components/HeroTicker.tsx
+++ b/src/components/HeroTicker.tsx
@@ -12,7 +12,7 @@ const items = [
 
 const ACCENT_FREQUENCY = 7;
 const ACCENT_OFFSET = 3;
-const ACCENT_COLORS = ["text-white", "text-red"] as const;
+const ACCENT_COLORS = ["text-neutral-900", "text-red"] as const;
 
 // Quante volte ripetere il set per OGNI metà (aumenta se servono schermi più larghi)
 const BASE_REPEATS_PER_HALF = 6;
@@ -69,12 +69,12 @@ export default function HeroTicker() {
         {track.map((item, idx) => {
           const isAccent = (idx + ACCENT_OFFSET) % ACCENT_FREQUENCY === 0;
           const accentIndex = Math.floor((idx + ACCENT_OFFSET) / ACCENT_FREQUENCY) % ACCENT_COLORS.length;
-          const accentClass = isAccent ? ACCENT_COLORS[accentIndex] : "text-white/80";
+          const accentClass = isAccent ? ACCENT_COLORS[accentIndex] : "text-neutral-600";
 
           return (
             <div
               key={`${item.label}-${idx}`}
-              className={`pointer-events-none inline-flex shrink-0 items-center gap-2 whitespace-nowrap rounded-full border border-white/20 bg-white/10 px-4 py-2 text-sm font-body backdrop-blur-md shadow-sm lg:px-5 lg:py-2.5 lg:text-base ${accentClass}`}
+              className={`pointer-events-none inline-flex shrink-0 items-center gap-2 whitespace-nowrap rounded-full border border-neutral-200 bg-white px-4 py-2 text-sm font-body shadow-sm lg:px-5 lg:py-2.5 lg:text-base ${accentClass}`}
               aria-hidden={idx >= half.length} /* la seconda metà serve solo per il loop */
             >
               <item.icon className="h-4 w-4 text-red" />

--- a/src/components/HowItWorks.tsx
+++ b/src/components/HowItWorks.tsx
@@ -20,8 +20,10 @@ export default function HowItWorks() {
       {...sectionProps}
     >
       <Container className="text-center">
-        <h2 className="font-heading font-bold tracking-[-0.5px] text-3xl">Come funziona Affinity?</h2>
-        <p className="mx-auto mt-4 max-w-2xl text-white">
+        <h2 className="font-heading text-3xl font-bold tracking-[-0.5px] text-neutral-900">
+          Come funziona Affinity?
+        </h2>
+        <p className="mx-auto mt-4 max-w-2xl text-neutral-600">
           Gratis il test, Premium la guida: insieme formano il percorso più rapido per capire e cambiare la tua vita amorosa.
         </p>
         <div className="relative mt-12">
@@ -32,17 +34,17 @@ export default function HowItWorks() {
               className={card}
               {...{ transition: { delay: 0.1 } }}
             >
-              <FileText className="mx-auto h-8 w-8 text-white animate-icon-bounce" />
-              <h3 className="mt-4 font-body text-lg font-semibold text-white">Rispondi al test</h3>
-              <p className="mt-2 text-sm text-white/80">30 domande, meno di 5 minuti.</p>
+              <FileText className="mx-auto h-8 w-8 text-red animate-icon-bounce" />
+              <h3 className="mt-4 font-body text-lg font-semibold text-neutral-900">Rispondi al test</h3>
+              <p className="mt-2 text-sm text-neutral-600">30 domande, meno di 5 minuti.</p>
             </motion.div>
             <motion.div
               className={card}
               {...{ transition: { delay: 0.2 } }}
             >
-              <BarChart2 className="mx-auto h-8 w-8 text-white animate-icon-bounce" />
-              <h3 className="mt-4 font-body text-lg font-semibold text-white">Scopri il tuo profilo</h3>
-              <p className="mt-2 text-sm text-white/80">
+              <BarChart2 className="mx-auto h-8 w-8 text-red animate-icon-bounce" />
+              <h3 className="mt-4 font-body text-lg font-semibold text-neutral-900">Scopri il tuo profilo</h3>
+              <p className="mt-2 text-sm text-neutral-600">
                 Punti di forza, errori invisibili e schemi che ti sabotano.
               </p>
             </motion.div>
@@ -50,9 +52,11 @@ export default function HowItWorks() {
               className={card}
               {...{ transition: { delay: 0.3 } }}
             >
-              <Key className="mx-auto h-8 w-8 text-white animate-icon-bounce" />
-              <h3 className="mt-4 font-body text-lg font-semibold text-white">Sblocca la Guida Premium</h3>
-              <p className="mt-2 text-sm text-white/80">Oltre 500 libri, studi e meta-analisi condensati in strategie pratiche e applicabili.</p>
+              <Key className="mx-auto h-8 w-8 text-red animate-icon-bounce" />
+              <h3 className="mt-4 font-body text-lg font-semibold text-neutral-900">Sblocca la Guida Premium</h3>
+              <p className="mt-2 text-sm text-neutral-600">
+                Oltre 500 libri, studi e meta-analisi condensati in strategie pratiche e applicabili.
+              </p>
             </motion.div>
           </div>
         </div>

--- a/src/components/Manifesto.tsx
+++ b/src/components/Manifesto.tsx
@@ -16,22 +16,22 @@ export default function Manifesto() {
     <motion.section className="py-10 sm:py-14" {...sectionProps}>
       <Container className="flex justify-center">
         <div className="aff-card relative max-w-5xl text-center">
-          <Heart className="mx-auto mb-6 h-8 w-8 text-white" />
-          <h2 className="relative mx-auto inline-block font-heading text-3xl font-bold tracking-[-0.5px] leading-tight text-white sm:text-4xl">
+          <Heart className="mx-auto mb-6 h-8 w-8 text-red" />
+          <h2 className="relative mx-auto inline-block font-heading text-3xl font-bold tracking-[-0.5px] leading-tight text-neutral-900 sm:text-4xl">
             Perché abbiamo creato Affinity
             <motion.span
-              className="absolute bottom-0 left-1/2 h-[2px] w-0 -translate-x-1/2 bg-white"
+              className="absolute bottom-0 left-1/2 h-[2px] w-0 -translate-x-1/2 bg-red"
               initial={{ width: 0 }}
               whileInView={{ width: "100%" }}
               viewport={{ once: true }}
               transition={{ duration: 0.6 }}
             />
           </h2>
-          <p className="mx-auto mt-4 max-w-3xl leading-relaxed text-white/80">
+          <p className="mx-auto mt-4 max-w-3xl leading-relaxed text-neutral-600">
             L’amore oggi è fatto di swipe. Superficiale, fugace.
             Noi ci siamo persi lì: relazioni che ripetono sempre lo stesso film.
-            Affinity nasce per farti ricentrare, far crescere <span className="font-semibold text-white">legami veri</span>.
-            È la <span className="font-semibold text-white">mappa</span> che avremmo voluto avere. Ora è qui, per te.
+            Affinity nasce per farti ricentrare, far crescere <span className="font-semibold text-neutral-900">legami veri</span>.
+            È la <span className="font-semibold text-neutral-900">mappa</span> che avremmo voluto avere. Ora è qui, per te.
           </p>
         </div>
       </Container>

--- a/src/components/MiniBenefits.tsx
+++ b/src/components/MiniBenefits.tsx
@@ -66,12 +66,12 @@ export default function MiniBenefits() {
                   : ""
               }`}
             >
-              <Icon className="h-12 w-12 text-white md:h-14 md:w-14" />
+              <Icon className="h-12 w-12 text-red md:h-14 md:w-14" />
               <div>
-                <h3 className="font-body text-2xl font-semibold text-white md:text-[1.75rem]">
+                <h3 className="font-body text-2xl font-semibold text-neutral-900 md:text-[1.75rem]">
                   {title}
                 </h3>
-                <p className="mt-2 text-base leading-relaxed text-white/80 md:text-lg md:leading-relaxed">
+                <p className="mt-2 text-base leading-relaxed text-neutral-600 md:text-lg md:leading-relaxed">
                   {desc}
                 </p>
               </div>

--- a/src/components/ProsConsSection.tsx
+++ b/src/components/ProsConsSection.tsx
@@ -21,8 +21,10 @@ export default function ProsConsSection() {
     >
       <Container className="max-w-none sm:max-w-[min(108rem,92vw)]">
         <div className="text-center">
-          <h2 className="font-heading font-bold tracking-[-0.5px] text-3xl">Perché Affinity è diverso da tutto il resto</h2>
-          <p className="mx-auto mt-4 max-w-2xl text-white">
+          <h2 className="font-heading text-3xl font-bold tracking-[-0.5px] text-neutral-900">
+            Perché Affinity è diverso da tutto il resto
+          </h2>
+          <p className="mx-auto mt-4 max-w-2xl text-neutral-600">
             Niente opinioni. Solo ciò che la scienza e l’esperienza reale dimostrano.
           </p>
         </div>
@@ -31,12 +33,12 @@ export default function ProsConsSection() {
             className={card}
             {...{ transition: { delay: 0.1 } }}
           >
-            <div className="relative mx-auto mb-6 flex h-16 w-16 items-center justify-center rounded-full bg-white/10 md:mx-0">
-              <span className="absolute inset-0 -z-10 rounded-full bg-white/20 blur-lg" />
-              <X className="h-10 w-10 text-white animate-icon-bounce" />
+            <div className="relative mx-auto mb-6 flex h-16 w-16 items-center justify-center rounded-full bg-red/10 md:mx-0">
+              <span className="absolute inset-0 -z-10 rounded-full bg-red/20 blur-lg" />
+              <X className="h-10 w-10 text-red animate-icon-bounce" />
             </div>
-            <h3 className="font-body font-semibold text-white">Problemi</h3>
-            <ul className="mt-4 space-y-3 text-base text-white/80 text-left">
+            <h3 className="font-body font-semibold text-neutral-900">Problemi</h3>
+            <ul className="mt-4 space-y-3 text-left text-base text-neutral-600">
               <li>Attiri sempre le persone sbagliate e finisce nello stesso modo.</li>
               <li>Dopo poco perdono interesse e non capisci perché.</li>
               <li>Su Google e TikTok trovi solo consigli banali e contraddittori.</li>
@@ -48,12 +50,12 @@ export default function ProsConsSection() {
             className={card}
             {...{ transition: { delay: 0.2 } }}
           >
-            <div className="relative mx-auto mb-6 flex h-16 w-16 items-center justify-center rounded-full bg-white/10 md:mx-0">
-              <span className="absolute inset-0 -z-10 rounded-full bg-white/20 blur-lg" />
-              <Check className="h-10 w-10 text-white animate-icon-bounce" />
+            <div className="relative mx-auto mb-6 flex h-16 w-16 items-center justify-center rounded-full bg-red/10 md:mx-0">
+              <span className="absolute inset-0 -z-10 rounded-full bg-red/20 blur-lg" />
+              <Check className="h-10 w-10 text-red animate-icon-bounce" />
             </div>
-            <h3 className="font-body font-semibold text-white">Soluzioni</h3>
-            <ul className="mt-4 space-y-3 text-base text-white/80 text-left">
+            <h3 className="font-body font-semibold text-neutral-900">Soluzioni</h3>
+            <ul className="mt-4 space-y-3 text-left text-base text-neutral-600">
               <li>Scopri subito perché ti accade sempre lo stesso schema.</li>
               <li>Capisci i tuoi errori nascosti e come smettere di ripeterli.</li>
               <li>Accedi alla Guida Premium: 500+ libri e studi tradotti in strategie chiare.</li>

--- a/src/components/SiteFooter.tsx
+++ b/src/components/SiteFooter.tsx
@@ -2,20 +2,20 @@ import Link from "next/link";
 
 export default function SiteFooter() {
   return (
-    <footer className="relative text-xs text-white">
-      <div className="pointer-events-none absolute inset-x-0 top-0 h-px bg-white/10" />
+    <footer className="relative text-xs text-neutral-600">
+      <div className="pointer-events-none absolute inset-x-0 top-0 h-px bg-neutral-200" />
       <div className="pointer-events-none absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-red/40 to-transparent blur-sm" />
       <div className="mx-auto max-w-container px-4 py-6 md:grid md:grid-cols-[auto,1fr,auto] md:items-center">
         <div className="order-1 flex flex-col items-center gap-2 md:order-1 md:flex-row md:items-center md:gap-6 md:justify-self-start">
           <Link
             href="/privacy"
-            className="px-2 py-2 text-white hover:text-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-red"
+            className="px-2 py-2 text-neutral-900 transition hover:text-red focus-visible:outline focus-visible:outline-2 focus-visible:outline-red"
           >
             Privacy
           </Link>
           <Link
             href="/termini"
-            className="px-2 py-2 text-white hover:text-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-red"
+            className="px-2 py-2 text-neutral-900 transition hover:text-red focus-visible:outline focus-visible:outline-2 focus-visible:outline-red"
           >
             Termini
           </Link>
@@ -25,12 +25,12 @@ export default function SiteFooter() {
             href="https://www.instagram.com/affinity.it?igsh=MXJ3bDJuM3pxdjNlbQ=="
             target="_blank"
             rel="noreferrer"
-            className="px-2 py-2 text-white hover:text-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-red"
+            className="px-2 py-2 text-neutral-900 transition hover:text-red focus-visible:outline focus-visible:outline-2 focus-visible:outline-red"
           >
             Instagram
           </a>
         </div>
-        <p className="order-3 mt-4 text-center text-white md:order-2 md:mt-0">
+        <p className="order-3 mt-4 text-center text-neutral-600 md:order-2 md:mt-0">
           Affinity — basato su oltre 500 libri, studi e meta-analisi sulle relazioni.
         </p>
       </div>


### PR DESCRIPTION
## Summary
- replace the animated gradient background with a static white backdrop in the layout
- retheme the global palette and shared card styles for a light UI
- update marketing sections, header, footer, and the results page to use dark text with red accents

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d7cb6abbc48328b1a425f1f8af785f