### PR TITLE
Refine glow styling for free trial CTA

### DIFF
--- a/src/components/CTAButton.tsx
+++ b/src/components/CTAButton.tsx
@@ -12,6 +12,7 @@ type Props = {
   disabled?: boolean;
   type?: "button" | "submit";
   style?: CSSProperties;
+  variant?: "gradient" | "dark";
 };
 
 const MotionLink = motion(Link);
@@ -34,10 +35,22 @@ export default function CTAButton({
   disabled = false,
   type = "button",
   style,
+  variant = "gradient",
 }: Props) {
-  const base = `inline-flex items-center justify-center rounded-2xl bg-gradient-to-r from-[#FF2D2D] to-[#FF7A7A] px-5 py-2 font-body font-semibold text-white transition-all ${
-    disabled ? "cursor-not-allowed opacity-50" : "hover:to-red-dim"
-  }`;
+  const variantBaseClasses =
+    variant === "dark"
+      ? "relative inline-flex items-center justify-center overflow-hidden rounded-2xl border border-white/15 bg-black/60 px-5 py-2 font-body font-semibold text-white shadow-[0_25px_60px_rgba(0,0,0,0.55)] backdrop-blur-xl transition-all duration-300 before:absolute before:inset-[-18%] before:-z-10 before:rounded-[inherit] before:bg-[radial-gradient(circle_at_center,rgba(255,70,70,0.65),rgba(255,70,70,0)_70%)] before:opacity-90 before:transition-opacity before:duration-300 before:content-[''] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-red"
+      : "inline-flex items-center justify-center rounded-2xl bg-gradient-to-r from-[#FF2D2D] to-[#FF7A7A] px-5 py-2 font-body font-semibold text-white transition-all";
+
+  const enabledStateClasses =
+    variant === "dark"
+      ? "hover:border-red/40 hover:shadow-[0_35px_70px_rgba(0,0,0,0.65)] hover:before:opacity-100"
+      : "hover:to-red-dim";
+
+  const disabledStateClasses = "cursor-not-allowed opacity-50";
+
+  const base = `${variantBaseClasses} ${disabled ? disabledStateClasses : enabledStateClasses}`;
+
   const touch = isTouchDevice();
   const motionProps = disabled || touch
     ? {}
@@ -50,6 +63,16 @@ export default function CTAButton({
     touchAction: "manipulation",
     ...style,
   };
+  const content =
+    variant === "dark"
+      ? (
+          <span className="bg-gradient-to-r from-[#FF2D2D] via-[#FF4A4A] to-[#FF7A7A] bg-clip-text text-transparent">
+            {children}
+          </span>
+        )
+      : (
+          children
+        );
   if (href) {
     return (
       <MotionLink
@@ -59,7 +82,7 @@ export default function CTAButton({
         onClick={onClick}
         style={styleWithTouchAction}
       >
-        {children}
+        {content}
       </MotionLink>
     );
   }
@@ -72,7 +95,7 @@ export default function CTAButton({
       type={type}
       style={styleWithTouchAction}
     >
-      {children}
+      {content}
     </motion.button>
   );
 }

--- a/src/components/FinalCTA.tsx
+++ b/src/components/FinalCTA.tsx
@@ -16,7 +16,7 @@ export default function FinalCTA() {
     <motion.section className="py-10 sm:py-14 text-center text-white" {...sectionProps}>
       <Container>
         <h2 className="font-heading font-bold tracking-[-0.5px] text-3xl text-white">Pronto a iniziare?</h2>
-        <CTAButton href="/test" className="mt-8 px-8 py-4">
+        <CTAButton href="/test" variant="dark" className="mt-8 px-8 py-4">
           {CTA_COPY}
         </CTAButton>
       </Container>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -180,6 +180,7 @@ export default function Header() {
           <div className="ml-2 hidden sm:block sm:ml-4">
             <CTAButton
               href="/test"
+              variant="dark"
               className="max-w-full !px-4 !py-2 text-xs sm:text-sm"
             >
               {CTA_COPY}

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -56,6 +56,7 @@ export default function HeroSection() {
             >
               <CTAButton
                 href="/test"
+                variant="dark"
                 className="w-full max-w-full !flex justify-center !px-5 !py-3 text-base sm:w-auto sm:!px-6 sm:!py-3 sm:text-lg xl:!px-7 xl:!py-3.5 xl:text-xl"
                 onClick={() => track("cta_click_hero")}
               >

--- a/src/components/StickyCTABar.tsx
+++ b/src/components/StickyCTABar.tsx
@@ -29,6 +29,7 @@ export default function StickyCTABar() {
       <div className="pointer-events-none mx-auto w-full max-w-screen-sm rounded-2xl border border-white/15 bg-black/80 px-4 py-3 shadow-[0_20px_45px_rgba(0,0,0,0.6)] backdrop-blur supports-[backdrop-filter]:backdrop-blur sm:max-w-screen-md">
         <CTAButton
           href="/test"
+          variant="dark"
           className="pointer-events-auto w-full max-w-full !flex justify-center !px-5 !py-3 text-base"
           onClick={() => track("cta_click_sticky")}
         >


### PR DESCRIPTION
## Summary
- soften the dark CTA background so it matches the translucent card treatment
- add a persistent radial red glow that intensifies on hover for the free trial entry points

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68d83fb8d548832896f92d5c775a2537